### PR TITLE
refactor: use regular frontend build config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,27 +76,15 @@ jobs:
           sentry-cli releases new "${{ needs.release.outputs.app-version }}"
           sentry-cli releases set-commits "${{ needs.release.outputs.app-version }}" --auto || true
 
-      - name: Build frontend with source maps (Windows)
+      - name: Build frontend with source maps
         env:
           TAURI_ENV_DEBUG: "true"
-          TAURI_ENV_PLATFORM: "windows"
         run: npm run build
 
-      - name: Upload source maps to Sentry (Windows)
+      - name: Upload source maps to Sentry
         run: |
           sentry-cli sourcemaps inject ./dist
-          sentry-cli sourcemaps upload --release="${{ needs.release.outputs.app-version }}" --dist="windows" ./dist
-
-      - name: Build frontend with source maps (Linux)
-        env:
-          TAURI_ENV_DEBUG: "true"
-          TAURI_ENV_PLATFORM: "linux"
-        run: npm run build
-
-      - name: Upload source maps to Sentry (Linux)
-        run: |
-          sentry-cli sourcemaps inject ./dist
-          sentry-cli sourcemaps upload --release="${{ needs.release.outputs.app-version }}" --dist="linux" ./dist
+          sentry-cli sourcemaps upload --release="${{ needs.release.outputs.app-version }}" ./dist
 
       - name: Download debug symbols
         uses: actions/download-artifact@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
   envPrefix: ["VITE_", "TAURI_ENV_*"],
   server: { port: 1420, strictPort: true, watch: { ignored: ["src-tauri/**"] } },
   build: {
-    minify: !process.env.TAURI_ENV_DEBUG ? "esbuild" : false,
     sourcemap: !!process.env.TAURI_ENV_DEBUG,
     chunkSizeWarningLimit: 1000,
   },


### PR DESCRIPTION
This PR simplifies the Vite config:

- Use the default build target (`baseline-widely-available`), since our previous fine-tuned config doesn't make sense, really.
- Always minify the build.