### PR TITLE
refactor: manually manage the current pattern ID

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,6 +24,7 @@
     // Enable when Vue.js base TS config target supports these features.
     "unicorn/no-array-reverse": "off",
     "unicorn/no-array-sort": "off",
+    "unicorn/prefer-at": "off",
 
     "unicorn/no-useless-undefined": "off",
     "unicorn/consistent-function-scoping": "off",

--- a/app/src/app/router.ts
+++ b/app/src/app/router.ts
@@ -10,9 +10,8 @@ export const router = createRouter({
     },
     {
       name: "pattern-editor",
-      path: "/pattern-editor/:patternId?",
+      path: "/pattern-editor",
       component: () => import("#pattern-editor/PatternEditorPage.vue"),
-      props: true,
     },
   ],
 });

--- a/app/src/modules/pattern-editor/PatternEditorPage.vue
+++ b/app/src/modules/pattern-editor/PatternEditorPage.vue
@@ -4,7 +4,6 @@ import { BlockUI, Splitter, SplitterPanel, useConfirm, useToast } from "@embroid
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 
 import { onMounted, toRaw, useTemplateRef, watch } from "vue";
-import { useRouter } from "vue-router";
 
 import { StartupApi } from "#shared/api/";
 import { useDragDrop, useI18n, useTauriListener } from "#shared/composables/";
@@ -15,11 +14,7 @@ import { CanvasToolbar } from "./components/canvas/";
 import { PalettePanel, PatternWorkspace, WelcomeScreen } from "./components/workspace/";
 import { PaletteMode, useEditorStateStore, usePatternFileStore, usePatternStore } from "./stores/";
 
-const props = defineProps<{ patternId?: string }>();
-
 const appWindow = getCurrentWebviewWindow();
-
-const router = useRouter();
 
 const confirm = useConfirm();
 const toast = useToast();
@@ -34,14 +29,14 @@ const dropZoneContainer = useTemplateRef("drop-zone");
 const { isOverDropZone } = useDragDrop(dropZoneContainer, async (paths) => {
   for (const [index, path] of paths.entries()) {
     const patternId = await patternFileStore.openPattern(path);
-    if (index === paths.length - 1) {
-      router.push({ name: "pattern-editor", params: { patternId } });
+    if (index === paths.length - 1 && patternId) {
+      patternFileStore.switchPattern(patternId);
     }
   }
 });
 
 watch(
-  () => props.patternId,
+  () => patternFileStore.currentPatternId,
   async (patternId) => {
     if (patternId) patternStore.pattern = await patternFileStore.loadPattern(patternId);
     else patternStore.pattern = undefined;
@@ -90,9 +85,8 @@ useShortcuts({
 
 onMounted(async () => {
   await patternFileStore.fetchOpenedPatterns();
-  if (!props.patternId && patternFileStore.openedPatterns.length) {
-    const pattern = patternFileStore.openedPatterns[0]!;
-    router.push({ name: "pattern-editor", params: { patternId: pattern.id } });
+  if (!patternFileStore.currentPatternId && patternFileStore.openedPatterns.length) {
+    patternFileStore.switchPattern(patternFileStore.openedPatterns[0]!.id);
   }
 
   const notifications = await StartupApi.getStartupNotifications();

--- a/app/src/modules/pattern-editor/components/PageHeader.vue
+++ b/app/src/modules/pattern-editor/components/PageHeader.vue
@@ -8,7 +8,6 @@ import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { openPath, openUrl } from "@tauri-apps/plugin-opener";
 
 import { computed } from "vue";
-import { useRouter } from "vue-router";
 
 import { useEditorModals } from "#pattern-editor/composables/";
 import { Fabric } from "#pattern-editor/lib/pattern/";
@@ -20,8 +19,6 @@ import { ANY_IMAGE_FILTER } from "#shared/constants";
 import { useSettingsStore } from "#shared/stores/";
 
 import { FilesApi } from "../api/";
-
-const router = useRouter();
 
 const confirm = useConfirm();
 const filePicker = useFilePicker();
@@ -45,7 +42,7 @@ const menus = computed<MenubarMenu[]>(() => [
           shortcut: "Ctrl+O",
           async onSelect() {
             const patternId = await patternFileStore.openPattern();
-            router.push({ name: "pattern-editor", params: { patternId } });
+            if (patternId) patternFileStore.switchPattern(patternId);
           },
         },
         {
@@ -55,8 +52,7 @@ const menus = computed<MenubarMenu[]>(() => [
             modals.patternCreationModal.open({
               fabric: Fabric.default(),
               async onSave(fabric) {
-                const patternId = await patternFileStore.createPattern(fabric);
-                router.push({ name: "pattern-editor", params: { patternId } });
+                patternFileStore.switchPattern(await patternFileStore.createPattern(fabric));
               },
             });
           },
@@ -91,7 +87,7 @@ const menus = computed<MenubarMenu[]>(() => [
                     imagePath,
                     imageDimensions: await FilesApi.getImageDimensions(imagePath),
                   }).result;
-                  if (patternId) router.push({ name: "pattern-editor", params: { patternId } });
+                  if (patternId) patternFileStore.switchPattern(patternId);
                 },
               },
             ],
@@ -135,14 +131,7 @@ const menus = computed<MenubarMenu[]>(() => [
           label: fluent.$t("app-menu-file-close"),
           shortcut: "Ctrl+W",
           disabled: !patternStore.pattern,
-          async onSelect() {
-            await patternFileStore.closePattern(patternStore.pattern!.id);
-
-            const openedPatternsNumber = patternFileStore.openedPatterns.length;
-            const patternId = patternFileStore.openedPatterns[openedPatternsNumber - 1]?.id;
-
-            router.push({ name: "pattern-editor", params: { patternId } });
-          },
+          onSelect: () => patternFileStore.closePattern(patternStore.pattern!.id),
         },
       ],
       [

--- a/app/src/modules/pattern-editor/components/workspace/WelcomeScreen.vue
+++ b/app/src/modules/pattern-editor/components/workspace/WelcomeScreen.vue
@@ -4,7 +4,6 @@ import { resolveResource, sep } from "@tauri-apps/api/path";
 import { openPath, openUrl } from "@tauri-apps/plugin-opener";
 
 import { computed } from "vue";
-import { useRouter } from "vue-router";
 
 import { useEditorModals } from "#pattern-editor/composables/";
 import { Fabric } from "#pattern-editor/lib/pattern/";
@@ -13,8 +12,6 @@ import { useI18n } from "#shared/composables/";
 import { useSettingsStore } from "#shared/stores/";
 
 import { EditorWorkspaceLayout } from "./layout/";
-
-const router = useRouter();
 
 const patternFileStore = usePatternFileStore();
 const settingsStore = useSettingsStore();
@@ -75,22 +72,21 @@ function handleInfoItemClick(item: InfoItemOptions) {
 
 async function openPattern() {
   const patternId = await patternFileStore.openPattern();
-  router.push({ name: "pattern-editor", params: { patternId } });
+  if (patternId) patternFileStore.switchPattern(patternId);
 }
 
 function createPattern() {
   modals.patternCreationModal.open({
     fabric: Fabric.default(),
     async onSave(fabric) {
-      const patternId = await patternFileStore.createPattern(fabric);
-      router.push({ name: "pattern-editor", params: { patternId } });
+      patternFileStore.switchPattern(await patternFileStore.createPattern(fabric));
     },
   });
 }
 
 async function openRecentFile(filePath: string) {
   const patternId = await patternFileStore.openPattern(filePath);
-  if (patternId) router.push({ name: "pattern-editor", params: { patternId } });
+  if (patternId) patternFileStore.switchPattern(patternId);
 }
 </script>
 

--- a/app/src/modules/pattern-editor/components/workspace/layout/EditorWorkspaceTabs.vue
+++ b/app/src/modules/pattern-editor/components/workspace/layout/EditorWorkspaceTabs.vue
@@ -1,27 +1,10 @@
 <script setup lang="ts">
 import { Button, Tabs } from "@embroiderly/ui";
 
-import { useRouter } from "vue-router";
-
 import { usePatternFileStore, usePatternStore } from "#pattern-editor/stores";
-
-const router = useRouter();
 
 const patternStore = usePatternStore();
 const patternFileStore = usePatternFileStore();
-
-function switchPattern(patternId: string) {
-  router.push({ name: "pattern-editor", params: { patternId } });
-}
-
-async function closePattern(patternId: string) {
-  await patternFileStore.closePattern(patternId);
-
-  const openedPatternsNumber = patternFileStore.openedPatterns.length;
-  const lastPatternId = patternFileStore.openedPatterns[openedPatternsNumber - 1]?.id;
-
-  router.push({ name: "pattern-editor", params: { patternId: lastPatternId } });
-}
 </script>
 
 <template>
@@ -38,7 +21,7 @@ async function closePattern(patternId: string) {
       trigger:
         'grow-0 min-w-20 hover:data-[state=inactive]:bg-accented hover:cursor-pointer data-[state=inactive]:border-r border-default rounded-none',
     }"
-    @update:model-value="switchPattern($event as string)"
+    @update:model-value="patternFileStore.switchPattern($event as string)"
   >
     <template #trailing="{ item }">
       <Button
@@ -50,7 +33,7 @@ async function closePattern(patternId: string) {
           'text-inverted': patternStore.pattern?.id === item.value,
           'text-default': patternStore.pattern?.id !== item.value,
         }"
-        @click.stop="closePattern(item.value as string)"
+        @click.stop="patternFileStore.closePattern(item.value as string)"
       />
     </template>
   </Tabs>

--- a/app/src/modules/pattern-editor/stores/usePatternFileStore.ts
+++ b/app/src/modules/pattern-editor/stores/usePatternFileStore.ts
@@ -20,9 +20,16 @@ export const usePatternFileStore = defineStore(
     const toast = useToast();
     const filePicker = useFilePicker();
 
+    const currentPatternId = ref<string>();
+
     const openedPatterns = ref<{ id: string; title: string }[]>([]);
     const recentPatterns = ref<string[]>([]);
+
     const loading = ref(false);
+
+    function switchPattern(id: string) {
+      currentPatternId.value = id;
+    }
 
     function addOpenedPattern(id: string, title: string) {
       if (openedPatterns.value.some((p) => p.id === id)) return;
@@ -147,8 +154,14 @@ export const usePatternFileStore = defineStore(
     async function closePattern(id: string, options?: FilesApi.ClosePatternOptions) {
       try {
         loading.value = true;
+
         await FilesApi.closePattern(id, options);
         removeOpenedPattern(id);
+
+        if (currentPatternId.value === id) {
+          const lastOpenedPattern = openedPatterns.value[openedPatterns.value.length - 1];
+          currentPatternId.value = lastOpenedPattern?.id;
+        }
       } catch (error) {
         if (error instanceof UnsavedChangesError) {
           const pattern = openedPatterns.value.find((p) => p.id === id)!;
@@ -209,9 +222,11 @@ export const usePatternFileStore = defineStore(
     }
 
     return {
+      currentPatternId,
       openedPatterns,
       recentPatterns,
       loading,
+      switchPattern,
       updateOpenedPattern,
       loadPattern,
       openPattern,


### PR DESCRIPTION
This change eliminates the reliance on the Vue Router for URL state management. As a result, we can confidently remove Vue Router from the project since Embroiderly functions as a single-page application.

The inclusion of Vue Router only adds unnecessary complexity without providing any benefits. Vue Router was originally introduced along with Nuxt UI, but we have already transitioned to a custom UI Kit.