### PR TITLE
test: use `vue3-snapshot-serializer` to serialize component snapshots

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-shamefully-hoist=true

--- a/app/src/modules/pattern-editor/components/toolbar/ToolSelect.test.ts
+++ b/app/src/modules/pattern-editor/components/toolbar/ToolSelect.test.ts
@@ -52,45 +52,6 @@ describe("ToolSelect", () => {
     });
   });
 
-  describe("Click Selection", () => {
-    test("a click on the main button emits the model value update", async () => {
-      const onUpdate = vi.fn();
-
-      const screen = page.render(ToolSelectWrapper, {
-        props: {
-          modelValue: "pencil",
-          items: MULTIPLE_ITEMS,
-          "onUpdate:modelValue": onUpdate,
-        },
-      });
-
-      const mainButton = screen.getByTestId("tool-selector-main-button");
-      await expect.element(mainButton).toBeEnabled();
-
-      await mainButton.click();
-      expect(onUpdate).toHaveBeenCalledWith(MULTIPLE_ITEMS[0].value);
-    });
-
-    test("a click on the disabled button does not emit the model value update", async () => {
-      const onUpdate = vi.fn();
-
-      const screen = page.render(ToolSelectWrapper, {
-        props: {
-          modelValue: "pencil",
-          items: MULTIPLE_ITEMS,
-          disabled: true,
-          "onUpdate:modelValue": onUpdate,
-        },
-      });
-
-      const mainButton = screen.getByTestId("tool-selector-main-button");
-      await expect.element(mainButton).toBeDisabled();
-
-      await mainButton.click();
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
-  });
-
   describe("Dropdown Interaction", () => {
     test("a click on the dropdown button opens the dropdown menu", async () => {
       const screen = page.render(ToolSelectWrapper, {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,7 @@
     "vue": "catalog:"
   },
   "devDependencies": {
+    "@iconify-json/lucide": "catalog:",
     "@histoire/plugin-vue": "catalog:",
     "@tailwindcss/vite": "catalog:",
     "@tsconfig/node24": "catalog:",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,6 +46,7 @@
     "vitest": "catalog:",
     "vitest-browser-vue": "catalog:",
     "vue-tsc": "catalog:",
+    "vue3-snapshot-serializer": "catalog:",
     "webdriverio": "catalog:",
     "wrangler": "catalog:"
   }

--- a/packages/ui/src/components/BlockUI/BlockUI.spec.ts
+++ b/packages/ui/src/components/BlockUI/BlockUI.spec.ts
@@ -12,7 +12,7 @@ describe("BlockUI", () => {
     });
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly when not blocked", async () => {
@@ -22,6 +22,6 @@ describe("BlockUI", () => {
     });
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/BlockUI/__snapshots__/BlockUI.spec.ts.snap
+++ b/packages/ui/src/components/BlockUI/__snapshots__/BlockUI.spec.ts.snap
@@ -2,33 +2,13 @@
 
 exports[`BlockUI > renders correctly when blocked 1`] = `
 <div>
-  <div
-    aria-busy="true"
-    class="relative"
-    data-slot="base"
-  >
-    
-    Content
-    
-    <div
-      class="absolute top-0 left-0 size-full bg-black/50"
-      data-slot="mask"
-    />
+  <div aria-busy="true" class="relative" data-slot="base">Content<div class="absolute bg-black/50 left-0 size-full top-0" data-slot="mask"></div>
   </div>
 </div>
 `;
 
 exports[`BlockUI > renders correctly when not blocked 1`] = `
 <div>
-  <div
-    aria-busy="false"
-    class="relative"
-    data-slot="base"
-  >
-    
-    Content
-    
-    <!--v-if-->
-  </div>
+  <div aria-busy="false" class="relative" data-slot="base">Content</div>
 </div>
 `;

--- a/packages/ui/src/components/Button/Button.spec.ts
+++ b/packages/ui/src/components/Button/Button.spec.ts
@@ -47,7 +47,7 @@ describe("Button", () => {
       const screen = page.render(Button, options);
       await nextTick();
 
-      expect(screen.container).toMatchSnapshot();
+      expect(screen.container.outerHTML).toMatchSnapshot();
     },
   );
 

--- a/packages/ui/src/components/Button/__snapshots__/Button.spec.ts.snap
+++ b/packages/ui/src/components/Button/__snapshots__/Button.spec.ts.snap
@@ -2,730 +2,213 @@
 
 exports[`Button > renders correctly with icon 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with icon and leading 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with icon and trailing 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="trailingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with label 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with leading and trailing icons 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="trailingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <span class="truncate" data-slot="label">Button</span>
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with leading icon 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with neutral variant ghost 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with neutral variant link 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with neutral variant outline 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm bg-default text-default ring-accented hover:bg-elevated focus-visible:outline-inverted active:bg-elevated disabled:bg-default"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-elevated aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-default disabled:bg-default disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-default text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with neutral variant soft 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-elevated text-default hover:bg-accented/75 focus-visible:outline-inverted active:bg-accented/75 disabled:bg-elevated"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-accented/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-elevated disabled:bg-elevated disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-accented/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with neutral variant solid 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-inverted text-inverted hover:bg-inverted/90 focus-visible:outline-inverted active:bg-inverted/90 disabled:bg-inverted aria-disabled:bg-inverted"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-inverted/90 aria-disabled:bg-inverted aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-inverted disabled:bg-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-inverted/90 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with neutral variant subtle 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm bg-elevated text-default ring-accented hover:bg-accented/75 focus-visible:outline-inverted active:bg-accented/75 disabled:bg-elevated"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-accented/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-elevated disabled:bg-elevated disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-accented/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-default text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with primary variant ghost 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-primary hover:bg-primary/10 focus-visible:outline-primary active:bg-primary/10"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/10 aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/10 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-primary text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with primary variant link 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm text-primary hover:text-primary/75 focus-visible:outline-primary active:text-primary/75"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:text-primary/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:cursor-pointer hover:text-primary/75 inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-primary text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with primary variant outline 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm text-primary ring-primary/50 hover:bg-primary/10 focus-visible:outline-primary active:bg-primary/10 disabled:bg-transparent"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/10 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/10 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-inset ring-primary/50 rounded-md text-primary text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with primary variant soft 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary/10 text-primary hover:bg-primary/15 focus-visible:outline-primary active:bg-primary/15 disabled:bg-primary/10"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/15 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary/10 disabled:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/15 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-primary text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with primary variant solid 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with primary variant subtle 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm bg-primary/10 text-primary ring-primary/25 hover:bg-primary/15 focus-visible:outline-primary active:bg-primary/15 disabled:bg-primary/10"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/15 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary/10 disabled:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/15 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-inset ring-primary/25 rounded-md text-primary text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with size lg 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 px-3 py-2 text-base bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-3 py-2 rounded-md text-base text-inverted transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with size md 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with size sm 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 px-2 py-1 text-xs bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2 py-1 rounded-md text-inverted text-xs transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with slots 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    Leading slot
-    
-    
-    Default slot
-    
-    
-    Trailing slot
-    
-  </button>
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">Leading slotDefault slotTrailing slot</button>
 </div>
 `;
 
 exports[`Button > renders correctly with square icon-only and size lg 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-2"
-    data-slot="base"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-5"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-slot="base">
+    <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with square icon-only and size md 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5"
-    data-slot="base"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with square icon-only and size sm 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1"
-    data-slot="base"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-3"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1 rounded-md text-inverted text-xs transition-colors" data-slot="base">
+    <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
 </div>
 `;
 
 exports[`Button > renders correctly with trailing icon 1`] = `
 <div>
-  <button
-    aria-disabled="false"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-slot="base"
-  >
-    
-    <!--v-if-->
-    
-    
-    <span
-      class="truncate"
-      data-slot="label"
-    >
-      Button
-    </span>
-    
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="trailingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
+  <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+    <span class="truncate" data-slot="label">Button</span>
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
 </div>
 `;

--- a/packages/ui/src/components/Button/__snapshots__/Button.spec.ts.snap
+++ b/packages/ui/src/components/Button/__snapshots__/Button.spec.ts.snap
@@ -3,7 +3,13 @@
 exports[`Button > renders correctly with icon 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
     <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
@@ -12,7 +18,13 @@ exports[`Button > renders correctly with icon 1`] = `
 exports[`Button > renders correctly with icon and leading 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
     <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
@@ -22,7 +34,13 @@ exports[`Button > renders correctly with icon and trailing 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
     <span class="truncate" data-slot="label">Button</span>
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
   </button>
 </div>
 `;
@@ -38,9 +56,21 @@ exports[`Button > renders correctly with label 1`] = `
 exports[`Button > renders correctly with leading and trailing icons 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
     <span class="truncate" data-slot="label">Button</span>
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
   </button>
 </div>
 `;
@@ -48,7 +78,13 @@ exports[`Button > renders correctly with leading and trailing icons 1`] = `
 exports[`Button > renders correctly with leading icon 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
     <span class="truncate" data-slot="label">Button</span>
   </button>
 </div>
@@ -183,7 +219,13 @@ exports[`Button > renders correctly with slots 1`] = `
 exports[`Button > renders correctly with square icon-only and size lg 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-slot="base">
-    <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
   </button>
 </div>
 `;
@@ -191,7 +233,13 @@ exports[`Button > renders correctly with square icon-only and size lg 1`] = `
 exports[`Button > renders correctly with square icon-only and size md 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
   </button>
 </div>
 `;
@@ -199,7 +247,13 @@ exports[`Button > renders correctly with square icon-only and size md 1`] = `
 exports[`Button > renders correctly with square icon-only and size sm 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1 rounded-md text-inverted text-xs transition-colors" data-slot="base">
-    <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
   </button>
 </div>
 `;
@@ -208,7 +262,13 @@ exports[`Button > renders correctly with trailing icon 1`] = `
 <div>
   <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
     <span class="truncate" data-slot="label">Button</span>
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+        <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+      </g>
+    </svg>
   </button>
 </div>
 `;

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.spec.ts
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.spec.ts
@@ -40,6 +40,6 @@ describe("ButtonIcon", () => {
     const screen = page.render(ButtonIconWrapper, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/ButtonIcon/__snapshots__/ButtonIcon.spec.ts.snap
+++ b/packages/ui/src/components/ButtonIcon/__snapshots__/ButtonIcon.spec.ts.snap
@@ -3,7 +3,12 @@
 exports[`ButtonIcon > renders correctly with color neutral 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-inverted/90 aria-disabled:bg-inverted aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-inverted disabled:bg-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-inverted/90 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -22,7 +27,12 @@ exports[`ButtonIcon > renders correctly with color neutral 1`] = `
 exports[`ButtonIcon > renders correctly with color primary 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -41,7 +51,12 @@ exports[`ButtonIcon > renders correctly with color primary 1`] = `
 exports[`ButtonIcon > renders correctly with custom class 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary font-medium gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -60,7 +75,12 @@ exports[`ButtonIcon > renders correctly with custom class 1`] = `
 exports[`ButtonIcon > renders correctly with default props 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -79,7 +99,12 @@ exports[`ButtonIcon > renders correctly with default props 1`] = `
 exports[`ButtonIcon > renders correctly with disabled 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="true" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open" disabled>
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -98,7 +123,9 @@ exports[`ButtonIcon > renders correctly with disabled 1`] = `
 exports[`ButtonIcon > renders correctly with loading 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="true" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open" disabled>
-    <svg aria-hidden="true" class="animate-spin shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="animate-spin iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -117,7 +144,12 @@ exports[`ButtonIcon > renders correctly with loading 1`] = `
 exports[`ButtonIcon > renders correctly with size lg 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -136,7 +168,12 @@ exports[`ButtonIcon > renders correctly with size lg 1`] = `
 exports[`ButtonIcon > renders correctly with size md 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -155,7 +192,12 @@ exports[`ButtonIcon > renders correctly with size md 1`] = `
 exports[`ButtonIcon > renders correctly with size sm 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1 rounded-md text-inverted text-xs transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -174,7 +216,12 @@ exports[`ButtonIcon > renders correctly with size sm 1`] = `
 exports[`ButtonIcon > renders correctly with size xl 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center rounded-md text-inverted transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -193,7 +240,12 @@ exports[`ButtonIcon > renders correctly with size xl 1`] = `
 exports[`ButtonIcon > renders correctly with size xs 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center rounded-md text-inverted transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -212,7 +264,12 @@ exports[`ButtonIcon > renders correctly with size xs 1`] = `
 exports[`ButtonIcon > renders correctly with variant ghost 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/10 aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/10 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -231,7 +288,12 @@ exports[`ButtonIcon > renders correctly with variant ghost 1`] = `
 exports[`ButtonIcon > renders correctly with variant link 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:text-primary/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:cursor-pointer hover:text-primary/75 inline-flex items-center justify-center p-1.5 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -250,7 +312,12 @@ exports[`ButtonIcon > renders correctly with variant link 1`] = `
 exports[`ButtonIcon > renders correctly with variant outline 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/10 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/10 hover:cursor-pointer inline-flex items-center justify-center p-1.5 ring ring-inset ring-primary/50 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -269,7 +336,12 @@ exports[`ButtonIcon > renders correctly with variant outline 1`] = `
 exports[`ButtonIcon > renders correctly with variant soft 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/15 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary/10 disabled:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/15 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -288,7 +360,12 @@ exports[`ButtonIcon > renders correctly with variant soft 1`] = `
 exports[`ButtonIcon > renders correctly with variant solid 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
@@ -307,7 +384,12 @@ exports[`ButtonIcon > renders correctly with variant solid 1`] = `
 exports[`ButtonIcon > renders correctly with variant subtle 1`] = `
 <div>
   <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/15 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary/10 disabled:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/15 hover:cursor-pointer inline-flex items-center justify-center p-1.5 ring ring-inset ring-primary/25 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
-    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+    <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+        <circle cx="12" cy="12" r="3" />
+      </g>
+    </svg>
   </button>
   <div data-reka-popper-content-wrapper>
     <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">

--- a/packages/ui/src/components/ButtonIcon/__snapshots__/ButtonIcon.spec.ts.snap
+++ b/packages/ui/src/components/ButtonIcon/__snapshots__/ButtonIcon.spec.ts.snap
@@ -2,1804 +2,323 @@
 
 exports[`ButtonIcon > renders correctly with color neutral 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-inverted text-inverted hover:bg-inverted/90 focus-visible:outline-inverted active:bg-inverted/90 disabled:bg-inverted aria-disabled:bg-inverted p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-inverted/90 aria-disabled:bg-inverted aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-inverted disabled:bg-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-inverted/90 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with color primary 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with custom class 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5 font-medium"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary font-medium gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with default props 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with disabled 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="true"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-    disabled=""
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="true" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open" disabled>
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with loading 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="true"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-    disabled=""
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4 animate-spin"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="true" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open" disabled>
+    <svg aria-hidden="true" class="animate-spin shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with size lg 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-2"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-5"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with size md 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with size sm 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-3"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1 rounded-md text-inverted text-xs transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with size xl 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center rounded-md text-inverted transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with size xs 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center rounded-md text-inverted transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with variant ghost 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 text-sm text-primary hover:bg-primary/10 focus-visible:outline-primary active:bg-primary/10 p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/10 aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/10 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with variant link 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-primary hover:text-primary/75 focus-visible:outline-primary active:text-primary/75 p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:text-primary/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:cursor-pointer hover:text-primary/75 inline-flex items-center justify-center p-1.5 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with variant outline 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 text-sm text-primary ring-primary/50 hover:bg-primary/10 focus-visible:outline-primary active:bg-primary/10 disabled:bg-transparent p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/10 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/10 hover:cursor-pointer inline-flex items-center justify-center p-1.5 ring ring-inset ring-primary/50 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with variant soft 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary/10 text-primary hover:bg-primary/15 focus-visible:outline-primary active:bg-primary/15 disabled:bg-primary/10 p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/15 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary/10 disabled:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/15 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with variant solid 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-inverted text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ButtonIcon > renders correctly with variant subtle 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    aria-disabled="false"
-    aria-label="Settings"
-    class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 text-sm bg-primary/10 text-primary ring-primary/25 hover:bg-primary/15 focus-visible:outline-primary active:bg-primary/15 disabled:bg-primary/10 p-1.5"
-    data-grace-area-trigger=""
-    data-slot="base"
-    data-state="instant-open"
-  >
-    
-    <svg
-      aria-hidden="true"
-      class="shrink-0 size-4"
-      data-slot="leadingIcon"
-      height="1em"
-      role="img"
-      viewBox="0 0 16 16"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
-    
-    
-    <!--v-if-->
-    
-    
-    <!--v-if-->
-    
+  <button aria-describedby="reka-tooltip-content-v-0" aria-disabled="false" aria-label="Settings" class="active:bg-primary/15 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary/10 disabled:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/15 hover:cursor-pointer inline-flex items-center justify-center p-1.5 ring ring-inset ring-primary/25 rounded-md text-primary text-sm transition-colors" data-grace-area-trigger data-slot="base" data-state="instant-open">
+    <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
   </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Settings
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Settings</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Settings
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Settings</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;

--- a/packages/ui/src/components/Checkbox/Checkbox.spec.ts
+++ b/packages/ui/src/components/Checkbox/Checkbox.spec.ts
@@ -23,7 +23,7 @@ describe("Checkbox", () => {
     const screen = page.render(Checkbox, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -38,7 +38,7 @@ describe("Checkbox", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/Checkbox/__snapshots__/Checkbox.spec.ts.snap
+++ b/packages/ui/src/components/Checkbox/__snapshots__/Checkbox.spec.ts.snap
@@ -2,81 +2,23 @@
 
 exports[`Checkbox > renders correctly with class 1`] = `
 <div>
-  <div
-    class="relative items-start inline-flex"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="inline-flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Checkbox > renders correctly with description 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-label="Label"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-label="Label" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
     </div>
-    <div
-      class="ms-2 w-full text-base"
-      data-slot="wrapper"
-    >
-      <label
-        class="block font-medium text-default"
-        data-slot="label"
-        for="v-0"
-      >
-        
-        Label
-        
-      </label>
-      <p
-        class="text-muted"
-        data-slot="description"
-      >
-        Description
-      </p>
+    <div class="ms-2 text-base w-full" data-slot="wrapper">
+      <label class="block font-medium text-default" data-slot="label" for="v-0">Label</label>
+      <p class="text-muted" data-slot="description">Description</p>
     </div>
   </div>
 </div>
@@ -84,140 +26,42 @@ exports[`Checkbox > renders correctly with description 1`] = `
 
 exports[`Checkbox > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="relative flex items-start opacity-75"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5 cursor-not-allowed"
-        data-disabled=""
-        data-slot="base"
-        data-state="unchecked"
-        disabled=""
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start opacity-75 relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-disabled data-slot="base" data-state="unchecked" disabled id="v-0" role="checkbox" type="button"></button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Checkbox > renders correctly with icon 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Checkbox > renders correctly with id 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-        data-slot="base"
-        data-state="unchecked"
-        id="id"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-slot="base" data-state="unchecked" id="id" role="checkbox" type="button"></button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Checkbox > renders correctly with label 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-label="Label"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-label="Label" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
     </div>
-    <div
-      class="ms-2 w-full text-base"
-      data-slot="wrapper"
-    >
-      <label
-        class="block font-medium text-default"
-        data-slot="label"
-        for="v-0"
-      >
-        
-        Label
-        
-      </label>
-      <!--v-if-->
+    <div class="ms-2 text-base w-full" data-slot="wrapper">
+      <label class="block font-medium text-default" data-slot="label" for="v-0">Label</label>
     </div>
   </div>
 </div>
@@ -225,189 +69,57 @@ exports[`Checkbox > renders correctly with label 1`] = `
 
 exports[`Checkbox > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Checkbox > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-5"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-4"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-5 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-4" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Checkbox > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-4"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-3"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-4 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-3" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Checkbox > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="checkbox"
-        type="button"
-      >
-        
-        <!---->
-        
-        <!--v-if-->
-      </button>
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Checkbox > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <!--v-if-->
-      <!--v-if-->
-    </div>
-    <div
-      class=""
-      data-slot="container"
-    >
-      
-      <div
-        class="relative flex items-start"
-        data-slot="root"
-      >
-        <div
-          class="flex items-center h-6"
-          data-slot="container"
-        >
-          <button
-            aria-checked="false"
-            aria-label="Label"
-            aria-required="false"
-            class="overflow-hidden rounded-sm ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-            data-slot="base"
-            data-state="unchecked"
-            id="v-0"
-            role="checkbox"
-            type="button"
-          >
-            
-            <!---->
-            
-            <!--v-if-->
-          </button>
+  <div class data-slot="root">
+    <div class data-slot="wrapper"></div>
+    <div class data-slot="container">
+      <div class="flex items-start relative" data-slot="root">
+        <div class="flex h-6 items-center" data-slot="container">
+          <button aria-checked="false" aria-label="Label" aria-required="false" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-sm size-5" data-slot="base" data-state="unchecked" id="v-0" role="checkbox" type="button"></button>
         </div>
-        <div
-          class="ms-2 w-full text-base"
-          data-slot="wrapper"
-        >
-          <label
-            class="block font-medium text-default"
-            data-slot="label"
-            for="v-0"
-          >
-            
-            Label
-            
-          </label>
-          <!--v-if-->
+        <div class="ms-2 text-base w-full" data-slot="wrapper">
+          <label class="block font-medium text-default" data-slot="label" for="v-0">Label</label>
         </div>
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/ColorPicker/ColorPicker.spec.ts
+++ b/packages/ui/src/components/ColorPicker/ColorPicker.spec.ts
@@ -17,7 +17,7 @@ describe("ColorPicker", () => {
     const screen = page.render(ColorPicker, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/ColorPicker/__snapshots__/ColorPicker.spec.ts.snap
+++ b/packages/ui/src/components/ColorPicker/__snapshots__/ColorPicker.spec.ts.snap
@@ -2,52 +2,15 @@
 
 exports[`ColorPicker > renders correctly with class 1`] = `
 <div>
-  <div
-    class="data-disabled:opacity-75 w-64"
-    data-slot="root"
-    data-v-0d9dad41=""
-  >
-    <div
-      class="flex gap-4"
-      data-slot="picker"
-      data-v-0d9dad41=""
-    >
-      <div
-        class="relative touch-none size-42"
-        data-slot="selector"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute inset-0 rounded-md"
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-          style="background-color: rgb(255, 0, 0);"
-        />
-        <div
-          class="absolute inset-0 rounded-md"
-          data-color-picker-selector=""
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-        />
-        <div
-          class="absolute size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="selectorThumb"
-          data-v-0d9dad41=""
-          style="left: 100%; top: 0%; background-color: rgb(255, 0, 0);"
-        />
+  <div class="data-disabled:opacity-75 w-64" data-slot="root">
+    <div class="flex gap-4" data-slot="picker">
+      <div class="relative size-42 touch-none" data-slot="selector">
+        <div class="absolute inset-0 rounded-md" data-slot="selectorBackground"></div>
+        <div class="absolute inset-0 rounded-md" data-color-picker-selector data-slot="selectorBackground"></div>
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed ring-2 ring-white rounded-full size-4" data-slot="selectorThumb"></div>
       </div>
-      <div
-        class="relative w-2 touch-none rounded-md h-42"
-        data-color-picker-track=""
-        data-slot="track"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute left-1/2 size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="trackThumb"
-          data-v-0d9dad41=""
-          style="top: 0%; background-color: rgb(255, 0, 0);"
-        />
+      <div class="h-42 relative rounded-md touch-none w-2" data-color-picker-track data-slot="track">
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed left-1/2 ring-2 ring-white rounded-full size-4" data-slot="trackThumb"></div>
       </div>
     </div>
   </div>
@@ -56,55 +19,15 @@ exports[`ColorPicker > renders correctly with class 1`] = `
 
 exports[`ColorPicker > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="data-disabled:opacity-75"
-    data-disabled="true"
-    data-slot="root"
-    data-v-0d9dad41=""
-  >
-    <div
-      class="flex gap-4"
-      data-slot="picker"
-      data-v-0d9dad41=""
-    >
-      <div
-        class="relative touch-none size-42"
-        data-slot="selector"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute inset-0 rounded-md"
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-          style="background-color: rgb(255, 0, 0);"
-        />
-        <div
-          class="absolute inset-0 rounded-md"
-          data-color-picker-selector=""
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-        />
-        <div
-          class="absolute size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-disabled="true"
-          data-slot="selectorThumb"
-          data-v-0d9dad41=""
-          style="left: 100%; top: 0%; background-color: rgb(255, 0, 0);"
-        />
+  <div class="data-disabled:opacity-75" data-disabled="true" data-slot="root">
+    <div class="flex gap-4" data-slot="picker">
+      <div class="relative size-42 touch-none" data-slot="selector">
+        <div class="absolute inset-0 rounded-md" data-slot="selectorBackground"></div>
+        <div class="absolute inset-0 rounded-md" data-color-picker-selector data-slot="selectorBackground"></div>
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed ring-2 ring-white rounded-full size-4" data-disabled="true" data-slot="selectorThumb"></div>
       </div>
-      <div
-        class="relative w-2 touch-none rounded-md h-42"
-        data-color-picker-track=""
-        data-slot="track"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute left-1/2 size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-disabled="true"
-          data-slot="trackThumb"
-          data-v-0d9dad41=""
-          style="top: 0%; background-color: rgb(255, 0, 0);"
-        />
+      <div class="h-42 relative rounded-md touch-none w-2" data-color-picker-track data-slot="track">
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed left-1/2 ring-2 ring-white rounded-full size-4" data-disabled="true" data-slot="trackThumb"></div>
       </div>
     </div>
   </div>
@@ -113,52 +36,15 @@ exports[`ColorPicker > renders correctly with disabled 1`] = `
 
 exports[`ColorPicker > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="data-disabled:opacity-75"
-    data-slot="root"
-    data-v-0d9dad41=""
-  >
-    <div
-      class="flex gap-4"
-      data-slot="picker"
-      data-v-0d9dad41=""
-    >
-      <div
-        class="relative touch-none size-46"
-        data-slot="selector"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute inset-0 rounded-md"
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-          style="background-color: rgb(255, 0, 0);"
-        />
-        <div
-          class="absolute inset-0 rounded-md"
-          data-color-picker-selector=""
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-        />
-        <div
-          class="absolute size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="selectorThumb"
-          data-v-0d9dad41=""
-          style="left: 100%; top: 0%; background-color: rgb(255, 0, 0);"
-        />
+  <div class="data-disabled:opacity-75" data-slot="root">
+    <div class="flex gap-4" data-slot="picker">
+      <div class="relative size-46 touch-none" data-slot="selector">
+        <div class="absolute inset-0 rounded-md" data-slot="selectorBackground"></div>
+        <div class="absolute inset-0 rounded-md" data-color-picker-selector data-slot="selectorBackground"></div>
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed ring-2 ring-white rounded-full size-4" data-slot="selectorThumb"></div>
       </div>
-      <div
-        class="relative w-2 touch-none rounded-md h-46"
-        data-color-picker-track=""
-        data-slot="track"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute left-1/2 size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="trackThumb"
-          data-v-0d9dad41=""
-          style="top: 0%; background-color: rgb(255, 0, 0);"
-        />
+      <div class="h-46 relative rounded-md touch-none w-2" data-color-picker-track data-slot="track">
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed left-1/2 ring-2 ring-white rounded-full size-4" data-slot="trackThumb"></div>
       </div>
     </div>
   </div>
@@ -167,52 +53,15 @@ exports[`ColorPicker > renders correctly with size lg 1`] = `
 
 exports[`ColorPicker > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="data-disabled:opacity-75"
-    data-slot="root"
-    data-v-0d9dad41=""
-  >
-    <div
-      class="flex gap-4"
-      data-slot="picker"
-      data-v-0d9dad41=""
-    >
-      <div
-        class="relative touch-none size-42"
-        data-slot="selector"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute inset-0 rounded-md"
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-          style="background-color: rgb(255, 0, 0);"
-        />
-        <div
-          class="absolute inset-0 rounded-md"
-          data-color-picker-selector=""
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-        />
-        <div
-          class="absolute size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="selectorThumb"
-          data-v-0d9dad41=""
-          style="left: 100%; top: 0%; background-color: rgb(255, 0, 0);"
-        />
+  <div class="data-disabled:opacity-75" data-slot="root">
+    <div class="flex gap-4" data-slot="picker">
+      <div class="relative size-42 touch-none" data-slot="selector">
+        <div class="absolute inset-0 rounded-md" data-slot="selectorBackground"></div>
+        <div class="absolute inset-0 rounded-md" data-color-picker-selector data-slot="selectorBackground"></div>
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed ring-2 ring-white rounded-full size-4" data-slot="selectorThumb"></div>
       </div>
-      <div
-        class="relative w-2 touch-none rounded-md h-42"
-        data-color-picker-track=""
-        data-slot="track"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute left-1/2 size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="trackThumb"
-          data-v-0d9dad41=""
-          style="top: 0%; background-color: rgb(255, 0, 0);"
-        />
+      <div class="h-42 relative rounded-md touch-none w-2" data-color-picker-track data-slot="track">
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed left-1/2 ring-2 ring-white rounded-full size-4" data-slot="trackThumb"></div>
       </div>
     </div>
   </div>
@@ -221,52 +70,15 @@ exports[`ColorPicker > renders correctly with size md 1`] = `
 
 exports[`ColorPicker > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="data-disabled:opacity-75"
-    data-slot="root"
-    data-v-0d9dad41=""
-  >
-    <div
-      class="flex gap-4"
-      data-slot="picker"
-      data-v-0d9dad41=""
-    >
-      <div
-        class="relative touch-none size-38"
-        data-slot="selector"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute inset-0 rounded-md"
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-          style="background-color: rgb(255, 0, 0);"
-        />
-        <div
-          class="absolute inset-0 rounded-md"
-          data-color-picker-selector=""
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-        />
-        <div
-          class="absolute size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="selectorThumb"
-          data-v-0d9dad41=""
-          style="left: 100%; top: 0%; background-color: rgb(255, 0, 0);"
-        />
+  <div class="data-disabled:opacity-75" data-slot="root">
+    <div class="flex gap-4" data-slot="picker">
+      <div class="relative size-38 touch-none" data-slot="selector">
+        <div class="absolute inset-0 rounded-md" data-slot="selectorBackground"></div>
+        <div class="absolute inset-0 rounded-md" data-color-picker-selector data-slot="selectorBackground"></div>
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed ring-2 ring-white rounded-full size-4" data-slot="selectorThumb"></div>
       </div>
-      <div
-        class="relative w-2 touch-none rounded-md h-38"
-        data-color-picker-track=""
-        data-slot="track"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute left-1/2 size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="trackThumb"
-          data-v-0d9dad41=""
-          style="top: 0%; background-color: rgb(255, 0, 0);"
-        />
+      <div class="h-38 relative rounded-md touch-none w-2" data-color-picker-track data-slot="track">
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed left-1/2 ring-2 ring-white rounded-full size-4" data-slot="trackThumb"></div>
       </div>
     </div>
   </div>
@@ -275,52 +87,15 @@ exports[`ColorPicker > renders correctly with size sm 1`] = `
 
 exports[`ColorPicker > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="data-disabled:opacity-75"
-    data-slot="root"
-    data-v-0d9dad41=""
-  >
-    <div
-      class="flex gap-4"
-      data-slot="picker"
-      data-v-0d9dad41=""
-    >
-      <div
-        class="relative touch-none size-42 rounded-lg"
-        data-slot="selector"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute inset-0 rounded-md"
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-          style="background-color: rgb(255, 0, 0);"
-        />
-        <div
-          class="absolute inset-0 rounded-md"
-          data-color-picker-selector=""
-          data-slot="selectorBackground"
-          data-v-0d9dad41=""
-        />
-        <div
-          class="absolute size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="selectorThumb"
-          data-v-0d9dad41=""
-          style="left: 100%; top: 0%; background-color: rgb(255, 0, 0);"
-        />
+  <div class="data-disabled:opacity-75" data-slot="root">
+    <div class="flex gap-4" data-slot="picker">
+      <div class="relative rounded-lg size-42 touch-none" data-slot="selector">
+        <div class="absolute inset-0 rounded-md" data-slot="selectorBackground"></div>
+        <div class="absolute inset-0 rounded-md" data-color-picker-selector data-slot="selectorBackground"></div>
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed ring-2 ring-white rounded-full size-4" data-slot="selectorThumb"></div>
       </div>
-      <div
-        class="relative w-2 touch-none rounded-md h-42"
-        data-color-picker-track=""
-        data-slot="track"
-        data-v-0d9dad41=""
-      >
-        <div
-          class="absolute left-1/2 size-4 -translate-1/2 cursor-pointer rounded-full ring-2 ring-white data-disabled:cursor-not-allowed"
-          data-slot="trackThumb"
-          data-v-0d9dad41=""
-          style="top: 0%; background-color: rgb(255, 0, 0);"
-        />
+      <div class="h-42 relative rounded-md touch-none w-2" data-color-picker-track data-slot="track">
+        <div class="-translate-1/2 absolute cursor-pointer data-disabled:cursor-not-allowed left-1/2 ring-2 ring-white rounded-full size-4" data-slot="trackThumb"></div>
       </div>
     </div>
   </div>

--- a/packages/ui/src/components/ConfirmDialog/ConfirmDialog.spec.ts
+++ b/packages/ui/src/components/ConfirmDialog/ConfirmDialog.spec.ts
@@ -23,6 +23,6 @@ describe("ConfirmDialog", () => {
     const screen = page.render(ConfirmDialog, { ...options });
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.spec.ts.snap
+++ b/packages/ui/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.spec.ts.snap
@@ -2,700 +2,119 @@
 
 exports[`ConfirmDialog > renders correctly with class 1`] = `
 <div>
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby="reka-dialog-description-v-2"
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] w-96"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="alertdialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4 pb-0"
-      data-slot="header"
-    >
+  <div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby="reka-dialog-description-v-2" aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2 w-96" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="alertdialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4 pb-0" data-slot="header">
       <div>
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          
-          Confirm
-          
-          
-        </h2>
-        <p
-          class="mt-1 text-sm whitespace-pre-line text-muted"
-          data-slot="description"
-          id="reka-dialog-description-v-2"
-        >
-          
-          
-          Are you sure?
-          
-          
-        </p>
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Confirm</h2>
+        <p class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description" id="reka-dialog-description-v-2">Are you sure?</p>
       </div>
     </header>
-    <footer
-      class="flex items-center justify-end gap-1.5 p-4"
-      data-slot="footer"
-    >
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm bg-default text-default ring-accented hover:bg-elevated focus-visible:outline-inverted active:bg-elevated disabled:bg-default"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Cancel
-        </span>
-        
-        
-        <!--v-if-->
-        
+    <footer class="flex gap-1.5 items-center justify-end p-4" data-slot="footer">
+      <button aria-disabled="false" class="active:bg-elevated aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-default disabled:bg-default disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Cancel</span>
       </button>
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-elevated text-default hover:bg-accented/75 focus-visible:outline-inverted active:bg-accented/75 disabled:bg-elevated"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          No
-        </span>
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" class="active:bg-accented/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-elevated disabled:bg-elevated disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-accented/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">No</span>
       </button>
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Yes
-        </span>
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Yes</span>
       </button>
     </footer>
-    
-    
-    
-    
-    
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;
 
 exports[`ConfirmDialog > renders correctly with noButton hidden 1`] = `
 <div>
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby="reka-dialog-description-v-2"
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out]"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="alertdialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4 pb-0"
-      data-slot="header"
-    >
+  <div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby="reka-dialog-description-v-2" aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="alertdialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4 pb-0" data-slot="header">
       <div>
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          
-          Confirm
-          
-          
-        </h2>
-        <p
-          class="mt-1 text-sm whitespace-pre-line text-muted"
-          data-slot="description"
-          id="reka-dialog-description-v-2"
-        >
-          
-          
-          Are you sure?
-          
-          
-        </p>
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Confirm</h2>
+        <p class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description" id="reka-dialog-description-v-2">Are you sure?</p>
       </div>
     </header>
-    <footer
-      class="flex items-center justify-end gap-1.5 p-4"
-      data-slot="footer"
-    >
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm bg-default text-default ring-accented hover:bg-elevated focus-visible:outline-inverted active:bg-elevated disabled:bg-default"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Cancel
-        </span>
-        
-        
-        <!--v-if-->
-        
+    <footer class="flex gap-1.5 items-center justify-end p-4" data-slot="footer">
+      <button aria-disabled="false" class="active:bg-elevated aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-default disabled:bg-default disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Cancel</span>
       </button>
-      <!--v-if-->
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Yes
-        </span>
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Yes</span>
       </button>
     </footer>
-    
-    
-    
-    
-    
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;
 
 exports[`ConfirmDialog > renders correctly with title and description 1`] = `
 <div>
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby="reka-dialog-description-v-2"
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out]"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="alertdialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4 pb-0"
-      data-slot="header"
-    >
+  <div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby="reka-dialog-description-v-2" aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="alertdialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4 pb-0" data-slot="header">
       <div>
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          
-          Confirm
-          
-          
-        </h2>
-        <p
-          class="mt-1 text-sm whitespace-pre-line text-muted"
-          data-slot="description"
-          id="reka-dialog-description-v-2"
-        >
-          
-          
-          Are you sure?
-          
-          
-        </p>
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Confirm</h2>
+        <p class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description" id="reka-dialog-description-v-2">Are you sure?</p>
       </div>
     </header>
-    <footer
-      class="flex items-center justify-end gap-1.5 p-4"
-      data-slot="footer"
-    >
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm bg-default text-default ring-accented hover:bg-elevated focus-visible:outline-inverted active:bg-elevated disabled:bg-default"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Cancel
-        </span>
-        
-        
-        <!--v-if-->
-        
+    <footer class="flex gap-1.5 items-center justify-end p-4" data-slot="footer">
+      <button aria-disabled="false" class="active:bg-elevated aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-default disabled:bg-default disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Cancel</span>
       </button>
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-elevated text-default hover:bg-accented/75 focus-visible:outline-inverted active:bg-accented/75 disabled:bg-elevated"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          No
-        </span>
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" class="active:bg-accented/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-elevated disabled:bg-elevated disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-accented/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">No</span>
       </button>
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Yes
-        </span>
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Yes</span>
       </button>
     </footer>
-    
-    
-    
-    
-    
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;
 
 exports[`ConfirmDialog > renders correctly with ui 1`] = `
 <div>
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby="reka-dialog-description-v-2"
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out]"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="alertdialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4 pb-0"
-      data-slot="header"
-    >
+  <div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby="reka-dialog-description-v-2" aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="alertdialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4 pb-0" data-slot="header">
       <div>
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          
-          Confirm
-          
-          
-        </h2>
-        <p
-          class="mt-1 text-sm whitespace-pre-line text-muted"
-          data-slot="description"
-          id="reka-dialog-description-v-2"
-        >
-          
-          
-          Are you sure?
-          
-          
-        </p>
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Confirm</h2>
+        <p class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description" id="reka-dialog-description-v-2">Are you sure?</p>
       </div>
     </header>
-    <footer
-      class="flex items-center gap-1.5 p-4 justify-start"
-      data-slot="footer"
-    >
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm bg-default text-default ring-accented hover:bg-elevated focus-visible:outline-inverted active:bg-elevated disabled:bg-default"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Cancel
-        </span>
-        
-        
-        <!--v-if-->
-        
+    <footer class="flex gap-1.5 items-center justify-start p-4" data-slot="footer">
+      <button aria-disabled="false" class="active:bg-elevated aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-default disabled:bg-default disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Cancel</span>
       </button>
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-elevated text-default hover:bg-accented/75 focus-visible:outline-inverted active:bg-accented/75 disabled:bg-elevated"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          No
-        </span>
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" class="active:bg-accented/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-elevated disabled:bg-elevated disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-accented/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">No</span>
       </button>
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Yes
-        </span>
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Yes</span>
       </button>
     </footer>
-    
-    
-    
-    
-    
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;
 
 exports[`ConfirmDialog > renders correctly with yesButton hidden 1`] = `
 <div>
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby="reka-dialog-description-v-2"
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out]"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="alertdialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4 pb-0"
-      data-slot="header"
-    >
+  <div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby="reka-dialog-description-v-2" aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="alertdialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4 pb-0" data-slot="header">
       <div>
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          
-          Confirm
-          
-          
-        </h2>
-        <p
-          class="mt-1 text-sm whitespace-pre-line text-muted"
-          data-slot="description"
-          id="reka-dialog-description-v-2"
-        >
-          
-          
-          Are you sure?
-          
-          
-        </p>
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Confirm</h2>
+        <p class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description" id="reka-dialog-description-v-2">Are you sure?</p>
       </div>
     </header>
-    <footer
-      class="flex items-center justify-end gap-1.5 p-4"
-      data-slot="footer"
-    >
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 ring ring-inset gap-1.5 px-2.5 py-1.5 text-sm bg-default text-default ring-accented hover:bg-elevated focus-visible:outline-inverted active:bg-elevated disabled:bg-default"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Cancel
-        </span>
-        
-        
-        <!--v-if-->
-        
+    <footer class="flex gap-1.5 items-center justify-end p-4" data-slot="footer">
+      <button aria-disabled="false" class="active:bg-elevated aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-default disabled:bg-default disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">Cancel</span>
       </button>
-      <button
-        aria-disabled="false"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm bg-elevated text-default hover:bg-accented/75 focus-visible:outline-inverted active:bg-accented/75 disabled:bg-elevated"
-        data-slot="base"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          No
-        </span>
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" class="active:bg-accented/75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-elevated disabled:bg-elevated disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-accented/75 hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-slot="base" type="button">
+        <span class="truncate" data-slot="label">No</span>
       </button>
-      <!--v-if-->
     </footer>
-    
-    
-    
-    
-    
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;

--- a/packages/ui/src/components/ContextMenu/ContextMenu.spec.ts
+++ b/packages/ui/src/components/ContextMenu/ContextMenu.spec.ts
@@ -59,9 +59,6 @@ describe("ContextMenu", () => {
     ["with simple items", { props: { ...props, items: simpleItems } }],
     ["with checkbox items", { props: { ...props, items: checkboxItems } }],
     ["with submenu items", { props: { ...props, items: submenuItems } }],
-    ["with disabled", { props: { ...props, items: simpleItems, disabled: true } }],
-    ...sizes.map((size) => [`with size ${size}`, { props: { ...props, items: simpleItems, size } }]),
-    ["with class", { props: { ...props, items: simpleItems, class: "min-w-48" } }],
     [
       "with shortcuts",
       {
@@ -77,6 +74,9 @@ describe("ContextMenu", () => {
         },
       },
     ],
+    ["with disabled", { props: { ...props, items: simpleItems, disabled: true } }],
+    ...sizes.map((size) => [`with size ${size}`, { props: { ...props, items: simpleItems, size } }]),
+    ["with class", { props: { ...props, items: simpleItems, class: "min-w-48" } }],
     ["with ui", { props: { ...props, items: simpleItems, ui: { content: "min-w-48" } } }],
   ] as [string, { props?: ContextMenuProps }][])("renders correctly %s", async (_, options) => {
     const screen = page.render(ContextMenuWrapper, options);
@@ -86,6 +86,6 @@ describe("ContextMenu", () => {
     await userEvent.click(trigger, { button: "right" });
 
     await nextTick();
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/ContextMenu/__snapshots__/ContextMenu.spec.ts.snap
+++ b/packages/ui/src/components/ContextMenu/__snapshots__/ContextMenu.spec.ts.snap
@@ -2,2346 +2,421 @@
 
 exports[`ContextMenu > renders correctly with checkbox items 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="flex w-full items-center font-semibold gap-1.5 p-1.5 text-sm"
-          data-slot="label"
-        >
-          
-          
-          View
-          
-          
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="flex font-semibold gap-1.5 items-center p-1.5 text-sm w-full" data-slot="label">View</div>
+        <div aria-orientation="horizontal" class="-mx-1 bg-border h-px my-1" data-slot="separator" role="separator"></div>
+        <div aria-checked="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="checked" role="menuitemcheckbox" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">Show Grid</span>
+          <svg aria-hidden="true" class="iconify iconify--lucide inline-flex items-center ms-auto shrink-0 size-5" data-slot="itemTrailingIcon" data-state="checked" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </div>
-        
-        
-        <div
-          aria-orientation="horizontal"
-          class="-mx-1 my-1 h-px bg-border"
-          data-slot="separator"
-          role="separator"
-        >
-          
-          
+        <div aria-checked="false" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="unchecked" role="menuitemcheckbox" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">Show Rulers</span>
         </div>
-        
-        
-        <div
-          aria-checked="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="checked"
-          role="menuitemcheckbox"
-          tabindex="-1"
-        >
-          
-          
-          
-          
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            Show Grid
-          </span>
-          <svg
-            aria-hidden="true"
-            class="ms-auto inline-flex items-center shrink-0 size-5"
-            data-slot="itemTrailingIcon"
-            data-state="checked"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          
-          
+        <div aria-checked="false" aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" data-state="unchecked" role="menuitemcheckbox" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">Snap to Grid</span>
         </div>
-        
-        
-        <div
-          aria-checked="false"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="unchecked"
-          role="menuitemcheckbox"
-          tabindex="-1"
-        >
-          
-          
-          
-          
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            Show Rulers
-          </span>
-          <!---->
-          
-          
-          
-          
-        </div>
-        
-        
-        <div
-          aria-checked="false"
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="unchecked"
-          role="menuitemcheckbox"
-          tabindex="-1"
-        >
-          
-          
-          
-          
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            Snap to Grid
-          </span>
-          <!---->
-          
-          
-          
-          
-        </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with class 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] min-w-48"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-48 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with disabled 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-disabled=""
-    data-state="closed"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <!---->
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
+  <span data-disabled data-state="closed">Trigger</span>
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with shortcuts 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Undo
-            </span>
-            <!--v-if-->
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Undo</span>
           </span>
-          <span
-            class="ms-auto inline-flex items-center flex items-center gap-0.5"
-            data-slot="itemTrailing"
-          >
-            
-            <kbd
-              class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-              data-slot="base"
-            >
-              Ctrl+Z
-            </kbd>
-            
+          <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+            <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+Z</kbd>
           </span>
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Redo
-            </span>
-            <!--v-if-->
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Redo</span>
           </span>
-          <span
-            class="ms-auto inline-flex items-center flex items-center gap-0.5"
-            data-slot="itemTrailing"
-          >
-            
-            <kbd
-              class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-              data-slot="base"
-            >
-              Ctrl+Shift+Z
-            </kbd>
-            
+          <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+            <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+Shift+Z</kbd>
           </span>
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Go to Definition
-            </span>
-            <!--v-if-->
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Go to Definition</span>
           </span>
-          <span
-            class="ms-auto inline-flex items-center flex items-center gap-0.5"
-            data-slot="itemTrailing"
-          >
-            
-            <kbd
-              class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-              data-slot="base"
-            >
-              G
-            </kbd>
-            <kbd
-              class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-              data-slot="base"
-            >
-              D
-            </kbd>
-            
+          <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+            <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">G</kbd>
+            <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">D</kbd>
           </span>
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with simple items 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
+            </g>
+          </svg>
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+            </g>
+          </svg>
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+            </g>
+          </svg>
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with size lg 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with size md 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with size sm 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-4"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-4 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-4"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-4 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-4"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-4 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with submenu items 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        
-        
-        
-        <div
-          aria-controls="reka-menu-sub-content-v-2"
-          aria-expanded="false"
-          aria-haspopup="menu"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="closed"
-          id="reka-menu-sub-trigger-v-0"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            File
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div aria-controls="reka-menu-sub-content-v-2" aria-expanded="false" aria-haspopup="menu" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="closed" id="reka-menu-sub-trigger-v-0" role="menuitem" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">File</span>
+          <span class="inline-flex items-center ms-auto" data-slot="itemTrailing">
+            <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <path d="m9 18l6-6l-6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+            </svg>
           </span>
-          <span
-            class="ms-auto inline-flex items-center"
-            data-slot="itemTrailing"
-          >
-            <svg
-              aria-hidden="true"
-              class="shrink-0 size-5"
-              data-slot="itemTrailingIcon"
-              height="1em"
-              role="img"
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            />
-          </span>
-          
-          
-          
         </div>
-        <!--teleport start-->
-        
-        
-        
-        <!---->
-        
-        
-        
-        <!--teleport end-->
-        
-        
-        
-        
-        
-        
-        
-        
-        <div
-          aria-controls="reka-menu-sub-content-v-3"
-          aria-expanded="false"
-          aria-haspopup="menu"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="closed"
-          id="reka-menu-sub-trigger-v-1"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            Edit
+        <div aria-controls="reka-menu-sub-content-v-3" aria-expanded="false" aria-haspopup="menu" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="closed" id="reka-menu-sub-trigger-v-1" role="menuitem" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">Edit</span>
+          <span class="inline-flex items-center ms-auto" data-slot="itemTrailing">
+            <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <path d="m9 18l6-6l-6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+            </svg>
           </span>
-          <span
-            class="ms-auto inline-flex items-center"
-            data-slot="itemTrailing"
-          >
-            <svg
-              aria-hidden="true"
-              class="shrink-0 size-5"
-              data-slot="itemTrailingIcon"
-              height="1em"
-              role="img"
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            />
-          </span>
-          
-          
-          
         </div>
-        <!--teleport start-->
-        
-        
-        
-        <!---->
-        
-        
-        
-        <!--teleport end-->
-        
-        
-        
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`ContextMenu > renders correctly with ui 1`] = `
 <div>
-  
-  
-  
-  
-  
-  
-  <span
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    Trigger
-  </span>
-  
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(24px, 7.2px); min-width: max-content; --reka-popper-transform-origin: 0px 0%; z-index: auto; --reka-popper-available-width: 386px; --reka-popper-available-height: 888px; --reka-popper-anchor-width: 0px; --reka-popper-anchor-height: 0px;"
-  >
-    <div
-      aria-orientation="vertical"
-      class="pointer-events-auto origin-(--reka-context-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] min-w-48"
-      data-align="start"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="right"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      role="menu"
-      style="--reka-context-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-context-menu-content-available-width: var(--reka-popper-available-width); --reka-context-menu-content-available-height: var(--reka-popper-available-height); --reka-context-menu-trigger-width: var(--reka-popper-anchor-width); --reka-context-menu-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span data-state="open">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-48 origin-(--reka-context-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="right" data-slot="content" data-state="open" dir="ltr" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;

--- a/packages/ui/src/components/Dialog/Dialog.spec.ts
+++ b/packages/ui/src/components/Dialog/Dialog.spec.ts
@@ -25,6 +25,6 @@ describe("Dialog", () => {
     });
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Dialog/__snapshots__/Dialog.spec.ts.snap
+++ b/packages/ui/src/components/Dialog/__snapshots__/Dialog.spec.ts.snap
@@ -8,7 +8,9 @@ exports[`Dialog > renders correctly with class 1`] = `
         <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
       </div>
       <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </header>
     <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
@@ -26,7 +28,9 @@ exports[`Dialog > renders correctly with description 1`] = `
         <p class="mt-1 text-muted text-sm" data-slot="description" id="reka-dialog-description-v-2">Are you sure?</p>
       </div>
       <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </header>
     <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
@@ -43,7 +47,9 @@ exports[`Dialog > renders correctly with non-dismissible 1`] = `
         <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
       </div>
       <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </header>
     <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
@@ -60,7 +66,9 @@ exports[`Dialog > renders correctly with title 1`] = `
         <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
       </div>
       <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </header>
     <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
@@ -77,7 +85,9 @@ exports[`Dialog > renders correctly with ui 1`] = `
         <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
       </div>
       <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </header>
     <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>

--- a/packages/ui/src/components/Dialog/__snapshots__/Dialog.spec.ts.snap
+++ b/packages/ui/src/components/Dialog/__snapshots__/Dialog.spec.ts.snap
@@ -1,548 +1,87 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Dialog > renders correctly with class 1`] = `
-<div>
-  
-  Open Dialog
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby=""
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col divide-y divide-default rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] w-96"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="dialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4"
-      data-slot="header"
-    >
-      <div
-        class="flex-1"
-      >
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          Dialog
-          
-        </h2>
-        <!--v-if-->
+<div>Open Dialog<div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] divide-default divide-y fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2 w-96" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="dialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4" data-slot="header">
+      <div class="flex-1">
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
       </div>
-      <button
-        aria-disabled="false"
-        aria-label="Close"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-1.5 absolute end-4 top-4"
-        data-slot="close"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-4"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </header>
-    <div
-      class="flex-1 overflow-y-auto p-4"
-      data-slot="body"
-    >
-      
-      Dialog body content
-      
-    </div>
-    <footer
-      class="flex items-center justify-end gap-1.5 p-4"
-      data-slot="footer"
-    >
-      
-      Footer content
-      
-    </footer>
-    
-    
-    
-    
+    <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
+    <footer class="flex gap-1.5 items-center justify-end p-4" data-slot="footer">Footer content</footer>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Dialog > renders correctly with description 1`] = `
-<div>
-  
-  Open Dialog
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col divide-y divide-default rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out]"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="dialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4"
-      data-slot="header"
-    >
-      <div
-        class="flex-1"
-      >
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          Dialog
-          
-        </h2>
-        <p
-          class="mt-1 text-sm text-muted"
-          data-slot="description"
-          id="reka-dialog-description-v-2"
-        >
-          
-          Are you sure?
-          
-        </p>
+<div>Open Dialog<div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] divide-default divide-y fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="dialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4" data-slot="header">
+      <div class="flex-1">
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
+        <p class="mt-1 text-muted text-sm" data-slot="description" id="reka-dialog-description-v-2">Are you sure?</p>
       </div>
-      <button
-        aria-disabled="false"
-        aria-label="Close"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-1.5 absolute end-4 top-4"
-        data-slot="close"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-4"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </header>
-    <div
-      class="flex-1 overflow-y-auto p-4"
-      data-slot="body"
-    >
-      
-      Dialog body content
-      
-    </div>
-    <footer
-      class="flex items-center justify-end gap-1.5 p-4"
-      data-slot="footer"
-    >
-      
-      Footer content
-      
-    </footer>
-    
-    
-    
-    
+    <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
+    <footer class="flex gap-1.5 items-center justify-end p-4" data-slot="footer">Footer content</footer>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Dialog > renders correctly with non-dismissible 1`] = `
-<div>
-  
-  Open Dialog
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby=""
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col divide-y divide-default rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out]"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="dialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4"
-      data-slot="header"
-    >
-      <div
-        class="flex-1"
-      >
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          Dialog
-          
-        </h2>
-        <!--v-if-->
+<div>Open Dialog<div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] divide-default divide-y fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="dialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4" data-slot="header">
+      <div class="flex-1">
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
       </div>
-      <button
-        aria-disabled="false"
-        aria-label="Close"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-1.5 absolute end-4 top-4"
-        data-slot="close"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-4"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </header>
-    <div
-      class="flex-1 overflow-y-auto p-4"
-      data-slot="body"
-    >
-      
-      Dialog body content
-      
-    </div>
-    <footer
-      class="flex items-center justify-end gap-1.5 p-4"
-      data-slot="footer"
-    >
-      
-      Footer content
-      
-    </footer>
-    
-    
-    
-    
+    <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
+    <footer class="flex gap-1.5 items-center justify-end p-4" data-slot="footer">Footer content</footer>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Dialog > renders correctly with title 1`] = `
-<div>
-  
-  Open Dialog
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby=""
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col divide-y divide-default rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out]"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="dialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4"
-      data-slot="header"
-    >
-      <div
-        class="flex-1"
-      >
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          Dialog
-          
-        </h2>
-        <!--v-if-->
+<div>Open Dialog<div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] divide-default divide-y fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="dialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4" data-slot="header">
+      <div class="flex-1">
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
       </div>
-      <button
-        aria-disabled="false"
-        aria-label="Close"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-1.5 absolute end-4 top-4"
-        data-slot="close"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-4"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </header>
-    <div
-      class="flex-1 overflow-y-auto p-4"
-      data-slot="body"
-    >
-      
-      Dialog body content
-      
-    </div>
-    <footer
-      class="flex items-center justify-end gap-1.5 p-4"
-      data-slot="footer"
-    >
-      
-      Footer content
-      
-    </footer>
-    
-    
-    
-    
+    <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
+    <footer class="flex gap-1.5 items-center justify-end p-4" data-slot="footer">Footer content</footer>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Dialog > renders correctly with ui 1`] = `
-<div>
-  
-  Open Dialog
-  <!--teleport start-->
-  
-  
-  <div
-    aria-hidden="true"
-    class="fixed inset-0 bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out]"
-    data-aria-hidden="true"
-    data-slot="overlay"
-    data-state="open"
-    style="pointer-events: auto;"
-  >
-    
-    
-  </div>
-  <div
-    aria-describedby=""
-    aria-labelledby="reka-dialog-title-v-1"
-    class="fixed top-1/2 left-1/2 flex size-max max-h-[90%] max-w-[90%] min-w-md -translate-1/2 flex-col divide-y divide-default rounded-lg bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out]"
-    data-dismissable-layer=""
-    data-slot="content"
-    data-state="open"
-    id="reka-dialog-content-v-0"
-    role="dialog"
-    style="pointer-events: auto;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    <header
-      class="flex min-h-12 items-center gap-1.5 p-4"
-      data-slot="header"
-    >
-      <div
-        class="flex-1"
-      >
-        <h2
-          class="font-semibold"
-          data-slot="title"
-          id="reka-dialog-title-v-1"
-        >
-          
-          Dialog
-          
-        </h2>
-        <!--v-if-->
+<div>Open Dialog<div aria-hidden="true" class="bg-elevated/75 data-[state=closed]:animate-[fade-out_200ms_ease-in] data-[state=open]:animate-[fade-in_200ms_ease-out] fixed inset-0" data-aria-hidden="true" data-slot="overlay" data-state="open"></div>
+  <div aria-describedby aria-labelledby="reka-dialog-title-v-1" class="-translate-1/2 bg-default data-[state=closed]:animate-[scale-out_200ms_ease-in] data-[state=open]:animate-[scale-in_200ms_ease-out] divide-default divide-y fixed flex flex-col focus:outline-none left-1/2 max-h-[90%] max-w-[90%] min-w-md ring ring-default rounded-lg shadow-lg size-max top-1/2" data-dismissable-layer data-slot="content" data-state="open" id="reka-dialog-content-v-0" role="dialog" tabindex="-1">
+    <header class="flex gap-1.5 items-center min-h-12 p-4" data-slot="header">
+      <div class="flex-1">
+        <h2 class="font-semibold" data-slot="title" id="reka-dialog-title-v-1">Dialog</h2>
       </div>
-      <button
-        aria-disabled="false"
-        aria-label="Close"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-1.5 absolute end-4 top-4"
-        data-slot="close"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-4"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Close" class="absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 end-4 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-md text-default text-sm top-4 transition-colors" data-slot="close" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </header>
-    <div
-      class="flex-1 overflow-y-auto p-4"
-      data-slot="body"
-    >
-      
-      Dialog body content
-      
-    </div>
-    <footer
-      class="flex items-center gap-1.5 p-4 justify-start"
-      data-slot="footer"
-    >
-      
-      Footer content
-      
-    </footer>
-    
-    
-    
-    
+    <div class="flex-1 overflow-y-auto p-4" data-slot="body">Dialog body content</div>
+    <footer class="flex gap-1.5 items-center justify-start p-4" data-slot="footer">Footer content</footer>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.spec.ts
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.spec.ts
@@ -86,6 +86,6 @@ describe("DropdownMenu", () => {
     await userEvent.click(trigger);
 
     await nextTick();
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/DropdownMenu/__snapshots__/DropdownMenu.spec.ts.snap
+++ b/packages/ui/src/components/DropdownMenu/__snapshots__/DropdownMenu.spec.ts.snap
@@ -2,2391 +2,398 @@
 
 exports[`DropdownMenu > renders correctly with checkbox items 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="flex w-full items-center font-semibold gap-1.5 p-1.5 text-sm"
-          data-slot="label"
-        >
-          
-          
-          View
-          
-          
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="flex font-semibold gap-1.5 items-center p-1.5 text-sm w-full" data-slot="label">View</div>
+        <div aria-orientation="horizontal" class="-mx-1 bg-border h-px my-1" data-slot="separator" role="separator"></div>
+        <div aria-checked="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="checked" role="menuitemcheckbox" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">Show Grid</span>
+          <svg aria-hidden="true" class="inline-flex items-center ms-auto shrink-0 size-5" data-slot="itemTrailingIcon" data-state="checked" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </div>
-        
-        
-        <div
-          aria-orientation="horizontal"
-          class="-mx-1 my-1 h-px bg-border"
-          data-slot="separator"
-          role="separator"
-        >
-          
-          
+        <div aria-checked="false" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="unchecked" role="menuitemcheckbox" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">Show Rulers</span>
         </div>
-        
-        
-        <div
-          aria-checked="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="checked"
-          role="menuitemcheckbox"
-          tabindex="-1"
-        >
-          
-          
-          
-          
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            Show Grid
-          </span>
-          <svg
-            aria-hidden="true"
-            class="ms-auto inline-flex items-center shrink-0 size-5"
-            data-slot="itemTrailingIcon"
-            data-state="checked"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          
-          
+        <div aria-checked="false" aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" data-state="unchecked" role="menuitemcheckbox" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">Snap to Grid</span>
         </div>
-        
-        
-        <div
-          aria-checked="false"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="unchecked"
-          role="menuitemcheckbox"
-          tabindex="-1"
-        >
-          
-          
-          
-          
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            Show Rulers
-          </span>
-          <!---->
-          
-          
-          
-          
-        </div>
-        
-        
-        <div
-          aria-checked="false"
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="unchecked"
-          role="menuitemcheckbox"
-          tabindex="-1"
-        >
-          
-          
-          
-          
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            Snap to Grid
-          </span>
-          <!---->
-          
-          
-          
-          
-        </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with class 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] min-w-48"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-48 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with disabled 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-expanded="false"
-    aria-haspopup="menu"
-    data-disabled=""
-    data-state="closed"
-    disabled="true"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <!---->
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
+  <span aria-expanded="false" aria-haspopup="menu" data-disabled data-state="closed" disabled="true" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with shortcuts 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Undo
-            </span>
-            <!--v-if-->
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Undo</span>
           </span>
-          <span
-            class="ms-auto inline-flex items-center flex items-center gap-0.5"
-            data-slot="itemTrailing"
-          >
-            
-            <kbd
-              class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-              data-slot="base"
-            >
-              Ctrl+Z
-            </kbd>
-            
+          <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+            <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+Z</kbd>
           </span>
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Redo
-            </span>
-            <!--v-if-->
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Redo</span>
           </span>
-          <span
-            class="ms-auto inline-flex items-center flex items-center gap-0.5"
-            data-slot="itemTrailing"
-          >
-            
-            <kbd
-              class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-              data-slot="base"
-            >
-              Ctrl+Shift+Z
-            </kbd>
-            
+          <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+            <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+Shift+Z</kbd>
           </span>
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Go to Definition
-            </span>
-            <!--v-if-->
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Go to Definition</span>
           </span>
-          <span
-            class="ms-auto inline-flex items-center flex items-center gap-0.5"
-            data-slot="itemTrailing"
-          >
-            
-            <kbd
-              class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-              data-slot="base"
-            >
-              G
-            </kbd>
-            <kbd
-              class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-              data-slot="base"
-            >
-              D
-            </kbd>
-            
+          <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+            <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">G</kbd>
+            <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">D</kbd>
           </span>
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with simple items 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with size lg 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with size md 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with size sm 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-4"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-4 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-4"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-4 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-4"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-4 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with submenu items 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        
-        
-        
-        <div
-          aria-controls="reka-menu-sub-content-v-4"
-          aria-expanded="false"
-          aria-haspopup="menu"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="closed"
-          id="reka-menu-sub-trigger-v-2"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            File
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div aria-controls="reka-menu-sub-content-v-4" aria-expanded="false" aria-haspopup="menu" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="closed" id="reka-menu-sub-trigger-v-2" role="menuitem" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">File</span>
+          <span class="inline-flex items-center ms-auto" data-slot="itemTrailing">
+            <svg aria-hidden="true" class="shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
           </span>
-          <span
-            class="ms-auto inline-flex items-center"
-            data-slot="itemTrailing"
-          >
-            <svg
-              aria-hidden="true"
-              class="shrink-0 size-5"
-              data-slot="itemTrailingIcon"
-              height="1em"
-              role="img"
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            />
-          </span>
-          
-          
-          
         </div>
-        <!--teleport start-->
-        
-        
-        
-        <!---->
-        
-        
-        
-        <!--teleport end-->
-        
-        
-        
-        
-        
-        
-        
-        
-        <div
-          aria-controls="reka-menu-sub-content-v-5"
-          aria-expanded="false"
-          aria-haspopup="menu"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          data-state="closed"
-          id="reka-menu-sub-trigger-v-3"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="truncate"
-            data-slot="itemLabel"
-          >
-            Edit
+        <div aria-controls="reka-menu-sub-content-v-5" aria-expanded="false" aria-haspopup="menu" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="closed" id="reka-menu-sub-trigger-v-3" role="menuitem" tabindex="-1">
+          <span class="truncate" data-slot="itemLabel">Edit</span>
+          <span class="inline-flex items-center ms-auto" data-slot="itemTrailing">
+            <svg aria-hidden="true" class="shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
           </span>
-          <span
-            class="ms-auto inline-flex items-center"
-            data-slot="itemTrailing"
-          >
-            <svg
-              aria-hidden="true"
-              class="shrink-0 size-5"
-              data-slot="itemTrailingIcon"
-              height="1em"
-              role="img"
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            />
-          </span>
-          
-          
-          
         </div>
-        <!--teleport start-->
-        
-        
-        
-        <!---->
-        
-        
-        
-        <!--teleport end-->
-        
-        
-        
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`DropdownMenu > renders correctly with ui 1`] = `
 <div>
-  
-  
-  
-  <span
-    aria-controls="reka-dropdown-menu-content-v-1"
-    aria-expanded="true"
-    aria-haspopup="menu"
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-state="open"
-    disabled="false"
-    id="reka-dropdown-menu-trigger-v-0"
-    type="button"
-  >
-    Trigger
-  </span>
-  <!--teleport start-->
-  
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 30.4px); min-width: max-content; --reka-popper-transform-origin: 50% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 857.5999996066093px; --reka-popper-anchor-width: 49.212501525878906px; --reka-popper-anchor-height: 21.600000381469727px;"
-  >
-    <div
-      aria-labelledby="reka-dropdown-menu-trigger-v-0"
-      aria-orientation="vertical"
-      class="pointer-events-auto origin-(--reka-dropdown-menu-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] min-w-48"
-      data-align="center"
-      data-dismissable-layer=""
-      data-orientation="vertical"
-      data-reka-menu-content=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      dir="ltr"
-      id="reka-dropdown-menu-content-v-1"
-      role="menu"
-      style="--reka-dropdown-menu-content-transform-origin: var(--reka-popper-transform-origin); --reka-dropdown-menu-content-available-width: var(--reka-popper-available-width); --reka-dropdown-menu-content-available-height: var(--reka-popper-available-height); --reka-dropdown-menu-trigger-width: var(--reka-popper-anchor-width); --reka-dropdown-menu-trigger-height: var(--reka-popper-anchor-height); outline: none; pointer-events: auto;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <circle
-                cx="6"
-                cy="6"
-                r="3"
-              />
-              <path
-                d="M8.12 8.12L12 12m8-8L8.12 15.88"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-              <path
-                d="M14.8 14.8L20 20"
-              />
+  <span aria-controls="reka-dropdown-menu-content-v-1" aria-expanded="true" aria-haspopup="menu" aria-hidden="true" data-aria-hidden="true" data-state="open" disabled="false" id="reka-dropdown-menu-trigger-v-0" type="button">Trigger</span>
+  <div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-48 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Cut
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="14"
-                rx="2"
-                ry="2"
-                width="14"
-                x="8"
-                y="8"
-              />
-              <path
-                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-              />
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Copy
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        <div
-          aria-disabled="true"
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <svg
-            aria-hidden="true"
-            class="iconify iconify--lucide shrink-0 text-dimmed group-data-highlighted:text-default size-5"
-            data-slot="itemLeadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            >
-              <rect
-                height="4"
-                rx="1"
-                ry="1"
-                width="8"
-                x="8"
-                y="2"
-              />
-              <path
-                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-              />
+        <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
             </g>
           </svg>
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Paste
-            </span>
-            <!--v-if-->
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      <div
-        class="isolate p-1"
-        data-slot="group"
-        role="group"
-      >
-        
-        
-        
-        
-        <div
-          class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-          data-reka-collection-item=""
-          data-slot="item"
-          role="menuitem"
-          tabindex="-1"
-        >
-          
-          
-          
-          <!--v-if-->
-          <span
-            class="flex min-w-0 flex-1 flex-col"
-          >
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Select All
-            </span>
-            <!--v-if-->
+      <div class="isolate p-1" data-slot="group" role="group">
+        <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+          <span class="flex flex-1 flex-col min-w-0">
+            <span class="truncate" data-slot="itemLabel">Select All</span>
           </span>
-          <!--v-if-->
-          
-          
-          
         </div>
-        
-        
-        
-        
       </div>
-      
-      
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;

--- a/packages/ui/src/components/DropdownMenu/__snapshots__/DropdownMenu.spec.ts.snap
+++ b/packages/ui/src/components/DropdownMenu/__snapshots__/DropdownMenu.spec.ts.snap
@@ -10,7 +10,9 @@ exports[`DropdownMenu > renders correctly with checkbox items 1`] = `
         <div aria-orientation="horizontal" class="-mx-1 bg-border h-px my-1" data-slot="separator" role="separator"></div>
         <div aria-checked="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="checked" role="menuitemcheckbox" tabindex="-1">
           <span class="truncate" data-slot="itemLabel">Show Grid</span>
-          <svg aria-hidden="true" class="inline-flex items-center ms-auto shrink-0 size-5" data-slot="itemTrailingIcon" data-state="checked" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide inline-flex items-center ms-auto shrink-0 size-5" data-slot="itemTrailingIcon" data-state="checked" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </div>
         <div aria-checked="false" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="unchecked" role="menuitemcheckbox" tabindex="-1">
           <span class="truncate" data-slot="itemLabel">Show Rulers</span>
@@ -128,19 +130,36 @@ exports[`DropdownMenu > renders correctly with simple items 1`] = `
     <div aria-labelledby="reka-dropdown-menu-trigger-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-dropdown-menu-content-v-1" role="menu" tabindex="-1">
       <div class="isolate p-1" data-slot="group" role="group">
         <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
-          <svg aria-hidden="true" class="group-data-highlighted:text-default shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12L12 12m8-8L8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8L20 20" />
+            </g>
+          </svg>
           <span class="flex flex-1 flex-col min-w-0">
             <span class="truncate" data-slot="itemLabel">Cut</span>
           </span>
         </div>
         <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
-          <svg aria-hidden="true" class="group-data-highlighted:text-default shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+            </g>
+          </svg>
           <span class="flex flex-1 flex-col min-w-0">
             <span class="truncate" data-slot="itemLabel">Copy</span>
           </span>
         </div>
         <div aria-disabled="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-disabled data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
-          <svg aria-hidden="true" class="group-data-highlighted:text-default shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="group-data-highlighted:text-default iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="itemLeadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <rect height="4" rx="1" ry="1" width="8" x="8" y="2" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+            </g>
+          </svg>
           <span class="flex flex-1 flex-col min-w-0">
             <span class="truncate" data-slot="itemLabel">Paste</span>
           </span>
@@ -329,13 +348,17 @@ exports[`DropdownMenu > renders correctly with submenu items 1`] = `
         <div aria-controls="reka-menu-sub-content-v-4" aria-expanded="false" aria-haspopup="menu" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="closed" id="reka-menu-sub-trigger-v-2" role="menuitem" tabindex="-1">
           <span class="truncate" data-slot="itemLabel">File</span>
           <span class="inline-flex items-center ms-auto" data-slot="itemTrailing">
-            <svg aria-hidden="true" class="shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+            <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <path d="m9 18l6-6l-6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+            </svg>
           </span>
         </div>
         <div aria-controls="reka-menu-sub-content-v-5" aria-expanded="false" aria-haspopup="menu" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="closed" id="reka-menu-sub-trigger-v-3" role="menuitem" tabindex="-1">
           <span class="truncate" data-slot="itemLabel">Edit</span>
           <span class="inline-flex items-center ms-auto" data-slot="itemTrailing">
-            <svg aria-hidden="true" class="shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+            <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <path d="m9 18l6-6l-6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+            </svg>
           </span>
         </div>
       </div>

--- a/packages/ui/src/components/FilePicker/FilePicker.spec.ts
+++ b/packages/ui/src/components/FilePicker/FilePicker.spec.ts
@@ -18,7 +18,7 @@ describe("FilePicker", () => {
     const screen = page.render(FilePicker, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("emits pick event when button is clicked", async () => {

--- a/packages/ui/src/components/FilePicker/__snapshots__/FilePicker.spec.ts.snap
+++ b/packages/ui/src/components/FilePicker/__snapshots__/FilePicker.spec.ts.snap
@@ -2,317 +2,91 @@
 
 exports[`FilePicker > renders correctly with class 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px w-64"
-  >
-    
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 px-3 py-2 text-base not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Choose file
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="-space-x-px inline-flex relative w-64">
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-3 py-2 rounded-md text-base text-inverted transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Choose file</span>
     </button>
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1 w-full"
-      data-slot="root"
-    >
-      <!--v-if-->
-      <input
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        readonly=""
-        type="text"
-      />
-      <!--v-if-->
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative w-full" data-slot="root">
+      <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" readonly type="text">
     </div>
-    
   </div>
 </div>
 `;
 
 exports[`FilePicker > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    <button
-      aria-disabled="true"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 px-3 py-2 text-base not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-      disabled=""
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Choose file
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="-space-x-px inline-flex relative">
+    <button aria-disabled="true" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-3 py-2 rounded-md text-base text-inverted transition-colors" data-slot="base" disabled>
+      <span class="truncate" data-slot="label">Choose file</span>
     </button>
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1 w-full"
-      data-slot="root"
-    >
-      <!--v-if-->
-      <input
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        disabled=""
-        id="v-0"
-        readonly=""
-        type="text"
-      />
-      <!--v-if-->
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative w-full" data-slot="root">
+      <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" disabled id="v-0" readonly type="text">
     </div>
-    
   </div>
 </div>
 `;
 
 exports[`FilePicker > renders correctly with model value 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 px-3 py-2 text-base not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Choose file
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="-space-x-px inline-flex relative">
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-3 py-2 rounded-md text-base text-inverted transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Choose file</span>
     </button>
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1 w-full"
-      data-slot="root"
-    >
-      <!--v-if-->
-      <input
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        readonly=""
-        type="text"
-      />
-      <!--v-if-->
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative w-full" data-slot="root">
+      <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" readonly type="text">
     </div>
-    
   </div>
 </div>
 `;
 
 exports[`FilePicker > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 px-3 py-2 text-base not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Choose file
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="-space-x-px inline-flex relative">
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-3 py-2 rounded-md text-base text-inverted transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Choose file</span>
     </button>
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1 w-full"
-      data-slot="root"
-    >
-      <!--v-if-->
-      <input
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        readonly=""
-        type="text"
-      />
-      <!--v-if-->
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative w-full" data-slot="root">
+      <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" readonly type="text">
     </div>
-    
   </div>
 </div>
 `;
 
 exports[`FilePicker > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Choose file
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="-space-x-px inline-flex relative">
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Choose file</span>
     </button>
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1 w-full"
-      data-slot="root"
-    >
-      <!--v-if-->
-      <input
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1.5 px-2.5 py-1.5 text-sm group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        readonly=""
-        type="text"
-      />
-      <!--v-if-->
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative w-full" data-slot="root">
+      <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1.5 group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" readonly type="text">
     </div>
-    
   </div>
 </div>
 `;
 
 exports[`FilePicker > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 px-2 py-1 text-xs not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Choose file
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="-space-x-px inline-flex relative">
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-2 py-1 rounded-md text-inverted text-xs transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Choose file</span>
     </button>
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1 w-full"
-      data-slot="root"
-    >
-      <!--v-if-->
-      <input
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1 px-2 py-1 text-xs group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        readonly=""
-        type="text"
-      />
-      <!--v-if-->
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative w-full" data-slot="root">
+      <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1 group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none px-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" readonly type="text">
     </div>
-    
   </div>
 </div>
 `;
 
 exports[`FilePicker > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px gap-4"
-  >
-    
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 px-3 py-2 text-base not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Choose file
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="-space-x-px gap-4 inline-flex relative">
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-3 py-2 rounded-md text-base text-inverted transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Choose file</span>
     </button>
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1 w-full"
-      data-slot="root"
-    >
-      <!--v-if-->
-      <input
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        readonly=""
-        type="text"
-      />
-      <!--v-if-->
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative w-full" data-slot="root">
+      <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" readonly type="text">
     </div>
-    
   </div>
 </div>
 `;

--- a/packages/ui/src/components/FormField/FormField.spec.ts
+++ b/packages/ui/src/components/FormField/FormField.spec.ts
@@ -30,7 +30,7 @@ describe("FormField", () => {
       const screen = page.render(FormFieldWrapper, options);
       await nextTick();
 
-      expect(screen.container).toMatchSnapshot();
+      expect(screen.container.outerHTML).toMatchSnapshot();
     },
   );
 

--- a/packages/ui/src/components/FormField/__snapshots__/FormField.spec.ts.snap
+++ b/packages/ui/src/components/FormField/__snapshots__/FormField.spec.ts.snap
@@ -2,71 +2,19 @@
 
 exports[`FormField > renders correctly with all elements 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          aria-describedby="v-0-hint v-0-description v-0-help"
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input aria-describedby="v-0-hint v-0-description v-0-help" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>
@@ -74,52 +22,16 @@ exports[`FormField > renders correctly with all elements 1`] = `
 
 exports[`FormField > renders correctly with class 1`] = `
 <div>
-  <div
-    class="custom-class"
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <!--v-if-->
+  <div class="custom-class" data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
       </div>
-      <!--v-if-->
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>
@@ -127,59 +39,17 @@ exports[`FormField > renders correctly with class 1`] = `
 
 exports[`FormField > renders correctly with description 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <!--v-if-->
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          aria-describedby="v-0-description"
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input aria-describedby="v-0-description" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>
@@ -187,59 +57,17 @@ exports[`FormField > renders correctly with description 1`] = `
 
 exports[`FormField > renders correctly with help 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <!--v-if-->
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
       </div>
-      <!--v-if-->
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          aria-describedby="v-0-help"
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input aria-describedby="v-0-help" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>
@@ -247,59 +75,17 @@ exports[`FormField > renders correctly with help 1`] = `
 
 exports[`FormField > renders correctly with hint 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <!--v-if-->
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          aria-describedby="v-0-hint"
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input aria-describedby="v-0-hint" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>
@@ -307,52 +93,16 @@ exports[`FormField > renders correctly with hint 1`] = `
 
 exports[`FormField > renders correctly with label 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <!--v-if-->
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
       </div>
-      <!--v-if-->
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>
@@ -360,52 +110,16 @@ exports[`FormField > renders correctly with label 1`] = `
 
 exports[`FormField > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="text-base"
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <!--v-if-->
+  <div class="text-base" data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
       </div>
-      <!--v-if-->
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>
@@ -413,52 +127,16 @@ exports[`FormField > renders correctly with size lg 1`] = `
 
 exports[`FormField > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="text-sm"
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <!--v-if-->
+  <div class="text-sm" data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
       </div>
-      <!--v-if-->
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1.5 px-2.5 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1.5 px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>
@@ -466,52 +144,16 @@ exports[`FormField > renders correctly with size md 1`] = `
 
 exports[`FormField > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="text-xs"
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <!--v-if-->
+  <div class="text-xs" data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
       </div>
-      <!--v-if-->
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1 px-2 py-1 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1 px-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>
@@ -519,52 +161,16 @@ exports[`FormField > renders correctly with size sm 1`] = `
 
 exports[`FormField > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="rounded-lg"
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <!--v-if-->
+  <div class="rounded-lg" data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
       </div>
-      <!--v-if-->
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/FormFieldGroup/FormFieldGroup.spec.ts
+++ b/packages/ui/src/components/FormFieldGroup/FormFieldGroup.spec.ts
@@ -22,7 +22,7 @@ describe("FormFieldGroup", () => {
     const screen = page.render(FormFieldGroup, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly with Button children", async () => {
@@ -39,7 +39,7 @@ describe("FormFieldGroup", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly with Input and Button children", async () => {
@@ -55,7 +55,7 @@ describe("FormFieldGroup", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly with InputNumber and Button children", async () => {
@@ -71,6 +71,6 @@ describe("FormFieldGroup", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/FormFieldGroup/__snapshots__/FormFieldGroup.spec.ts.snap
+++ b/packages/ui/src/components/FormFieldGroup/__snapshots__/FormFieldGroup.spec.ts.snap
@@ -2,226 +2,72 @@
 
 exports[`FormFieldGroup > renders correctly with Button children 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        First
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="-space-x-px inline-flex relative">
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">First</span>
     </button>
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Second
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Second</span>
     </button>
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Third
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Third</span>
     </button>
-    
   </div>
 </div>
 `;
 
 exports[`FormFieldGroup > renders correctly with Input and Button children 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1"
-      data-slot="root"
-    >
-      <!--v-if-->
-      <input
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1.5 px-2.5 py-1.5 text-sm group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        type="text"
-      />
-      <!--v-if-->
+  <div class="-space-x-px inline-flex relative">
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative" data-slot="root">
+      <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1.5 group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" type="text">
     </div>
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Submit
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Submit</span>
     </button>
-    
   </div>
 </div>
 `;
 
 exports[`FormFieldGroup > renders correctly with InputNumber and Button children 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    <div
-      class="relative inline-flex items-center group has-focus-visible:z-1"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        aria-valuenow="5"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1.5 ps-2.5 text-sm group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-2.5"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value="5"
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="-space-x-px inline-flex relative">
+    <div class="group has-focus-visible:z-1 inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" aria-valuenow="5" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none group-not-last:group-not-first:rounded-none group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none pe-2.5 ps-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value="5">
     </div>
-    <button
-      aria-disabled="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 px-2.5 py-1.5 text-sm not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none focus-visible:z-1 bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-      data-slot="base"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Apply
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:z-1 gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center not-last:not-first:rounded-none not-only:first:rounded-e-none not-only:last:rounded-s-none px-2.5 py-1.5 rounded-md text-inverted text-sm transition-colors" data-slot="base">
+      <span class="truncate" data-slot="label">Apply</span>
     </button>
-    
   </div>
 </div>
 `;
 
 exports[`FormFieldGroup > renders correctly with class 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px custom-class"
-  >
-    
-    
-  </div>
+  <div class="-space-x-px custom-class inline-flex relative"></div>
 </div>
 `;
 
 exports[`FormFieldGroup > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    
-  </div>
+  <div class="-space-x-px inline-flex relative"></div>
 </div>
 `;
 
 exports[`FormFieldGroup > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    
-  </div>
+  <div class="-space-x-px inline-flex relative"></div>
 </div>
 `;
 
 exports[`FormFieldGroup > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px"
-  >
-    
-    
-  </div>
+  <div class="-space-x-px inline-flex relative"></div>
 </div>
 `;
 
 exports[`FormFieldGroup > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="relative inline-flex -space-x-px rounded-lg"
-  >
-    
-    
-  </div>
+  <div class="-space-x-px inline-flex relative rounded-lg"></div>
 </div>
 `;

--- a/packages/ui/src/components/FormFieldSet/FormFieldSet.spec.ts
+++ b/packages/ui/src/components/FormFieldSet/FormFieldSet.spec.ts
@@ -20,7 +20,7 @@ describe("FormFieldSet", () => {
     const screen = page.render(FormFieldSet, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("toggles open state when collapsible trigger is clicked", async () => {

--- a/packages/ui/src/components/FormFieldSet/__snapshots__/FormFieldSet.spec.ts.snap
+++ b/packages/ui/src/components/FormFieldSet/__snapshots__/FormFieldSet.spec.ts.snap
@@ -2,169 +2,62 @@
 
 exports[`FormFieldSet > renders correctly with class 1`] = `
 <div>
-  <fieldset
-    class="mt-2 rounded-md border border-default px-4 pb-4 custom-class"
-    data-slot="root"
-  >
-    <legend
-      class="font-medium text-default text-base"
-      data-slot="legend"
-    >
-      Legend
-    </legend>
-    
-    
+  <fieldset class="border border-default custom-class mt-2 pb-4 px-4 rounded-md" data-slot="root">
+    <legend class="font-medium text-base text-default" data-slot="legend">Legend</legend>
   </fieldset>
 </div>
 `;
 
 exports[`FormFieldSet > renders correctly with collapsible 1`] = `
 <div>
-  <fieldset
-    class="mt-2 rounded-md border border-default px-4 pb-4"
-    data-slot="root"
-    data-state="open"
-  >
-    
-    <legend
-      class="font-medium text-default text-base"
-      data-slot="legend"
-    >
-      <button
-        aria-controls=""
-        aria-disabled="false"
-        aria-expanded="true"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 px-3 py-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-        data-slot="base"
-        data-state="open"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          Legend
-        </span>
-        
-        
-        <!--v-if-->
-        
+  <fieldset class="border border-default mt-2 pb-4 px-4 rounded-md" data-slot="root" data-state="open">
+    <legend class="font-medium text-base text-default" data-slot="legend">
+      <button aria-controls aria-disabled="false" aria-expanded="true" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-3 py-2 rounded-md text-base text-default transition-colors" data-slot="base" data-state="open" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <span class="truncate" data-slot="label">Legend</span>
       </button>
     </legend>
-    <div
-      class="overflow-hidden data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=open]:animate-[collapsible-down_200ms_ease-out]"
-      data-slot="content"
-      id="reka-collapsible-content-v-0"
-      style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;"
-    >
-      
-      
-    </div>
-    
+    <div class="data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=open]:animate-[collapsible-down_200ms_ease-out] overflow-hidden" data-slot="content" id="reka-collapsible-content-v-0"></div>
   </fieldset>
 </div>
 `;
 
 exports[`FormFieldSet > renders correctly with legend 1`] = `
 <div>
-  <fieldset
-    class="mt-2 rounded-md border border-default px-4 pb-4"
-    data-slot="root"
-  >
-    <legend
-      class="font-medium text-default text-base"
-      data-slot="legend"
-    >
-      Legend
-    </legend>
-    
-    
+  <fieldset class="border border-default mt-2 pb-4 px-4 rounded-md" data-slot="root">
+    <legend class="font-medium text-base text-default" data-slot="legend">Legend</legend>
   </fieldset>
 </div>
 `;
 
 exports[`FormFieldSet > renders correctly with size lg 1`] = `
 <div>
-  <fieldset
-    class="mt-2 rounded-md border border-default px-4 pb-4"
-    data-slot="root"
-  >
-    <legend
-      class="font-medium text-default text-base"
-      data-slot="legend"
-    >
-      Legend
-    </legend>
-    
-    
+  <fieldset class="border border-default mt-2 pb-4 px-4 rounded-md" data-slot="root">
+    <legend class="font-medium text-base text-default" data-slot="legend">Legend</legend>
   </fieldset>
 </div>
 `;
 
 exports[`FormFieldSet > renders correctly with size md 1`] = `
 <div>
-  <fieldset
-    class="mt-2 rounded-md border border-default px-4 pb-4"
-    data-slot="root"
-  >
-    <legend
-      class="font-medium text-default text-sm"
-      data-slot="legend"
-    >
-      Legend
-    </legend>
-    
-    
+  <fieldset class="border border-default mt-2 pb-4 px-4 rounded-md" data-slot="root">
+    <legend class="font-medium text-default text-sm" data-slot="legend">Legend</legend>
   </fieldset>
 </div>
 `;
 
 exports[`FormFieldSet > renders correctly with size sm 1`] = `
 <div>
-  <fieldset
-    class="mt-2 rounded-md border border-default px-4 pb-4"
-    data-slot="root"
-  >
-    <legend
-      class="font-medium text-default text-xs"
-      data-slot="legend"
-    >
-      Legend
-    </legend>
-    
-    
+  <fieldset class="border border-default mt-2 pb-4 px-4 rounded-md" data-slot="root">
+    <legend class="font-medium text-default text-xs" data-slot="legend">Legend</legend>
   </fieldset>
 </div>
 `;
 
 exports[`FormFieldSet > renders correctly with ui 1`] = `
 <div>
-  <fieldset
-    class="mt-2 border border-default px-4 pb-4 rounded-lg"
-    data-slot="root"
-  >
-    <legend
-      class="font-medium text-default text-base"
-      data-slot="legend"
-    >
-      Legend
-    </legend>
-    
-    
+  <fieldset class="border border-default mt-2 pb-4 px-4 rounded-lg" data-slot="root">
+    <legend class="font-medium text-base text-default" data-slot="legend">Legend</legend>
   </fieldset>
 </div>
 `;

--- a/packages/ui/src/components/FormFieldSet/__snapshots__/FormFieldSet.spec.ts.snap
+++ b/packages/ui/src/components/FormFieldSet/__snapshots__/FormFieldSet.spec.ts.snap
@@ -13,7 +13,9 @@ exports[`FormFieldSet > renders correctly with collapsible 1`] = `
   <fieldset class="border border-default mt-2 pb-4 px-4 rounded-md" data-slot="root" data-state="open">
     <legend class="font-medium text-base text-default" data-slot="legend">
       <button aria-controls aria-disabled="false" aria-expanded="true" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-3 py-2 rounded-md text-base text-default transition-colors" data-slot="base" data-state="open" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="M5 12h14" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
         <span class="truncate" data-slot="label">Legend</span>
       </button>
     </legend>

--- a/packages/ui/src/components/Icon/Icon.spec.ts
+++ b/packages/ui/src/components/Icon/Icon.spec.ts
@@ -13,6 +13,6 @@ describe("Icon", () => {
     const screen = page.render(Icon, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Icon/__snapshots__/Icon.spec.ts.snap
+++ b/packages/ui/src/components/Icon/__snapshots__/Icon.spec.ts.snap
@@ -2,29 +2,12 @@
 
 exports[`Icon > renders correctly with class 1`] = `
 <div>
-  <svg
-    aria-hidden="true"
-    class="size-8"
-    height="1em"
-    role="img"
-    viewBox="0 0 16 16"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-  />
+  <svg aria-hidden="true" class="size-8" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
 </div>
 `;
 
 exports[`Icon > renders correctly with icon 1`] = `
 <div>
-  <svg
-    aria-hidden="true"
-    height="1em"
-    role="img"
-    viewBox="0 0 16 16"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-  />
+  <svg aria-hidden="true" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
 </div>
 `;

--- a/packages/ui/src/components/Icon/__snapshots__/Icon.spec.ts.snap
+++ b/packages/ui/src/components/Icon/__snapshots__/Icon.spec.ts.snap
@@ -2,12 +2,24 @@
 
 exports[`Icon > renders correctly with class 1`] = `
 <div>
-  <svg aria-hidden="true" class="size-8" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+  <svg aria-hidden="true" class="iconify iconify--lucide size-8" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+      <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+      <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+      <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+    </g>
+  </svg>
 </div>
 `;
 
 exports[`Icon > renders correctly with icon 1`] = `
 <div>
-  <svg aria-hidden="true" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+  <svg aria-hidden="true" class="iconify iconify--lucide" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+      <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+      <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+      <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+    </g>
+  </svg>
 </div>
 `;

--- a/packages/ui/src/components/Input/Input.spec.ts
+++ b/packages/ui/src/components/Input/Input.spec.ts
@@ -29,7 +29,7 @@ describe("Input", () => {
     const screen = page.render(Input, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -44,7 +44,7 @@ describe("Input", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/Input/__snapshots__/Input.spec.ts.snap
+++ b/packages/ui/src/components/Input/__snapshots__/Input.spec.ts.snap
@@ -2,141 +2,48 @@
 
 exports[`Input > renders correctly with class 1`] = `
 <div>
-  <div
-    class="inline-flex items-center absolute"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+  <div class="absolute inline-flex items-center" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      disabled=""
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" disabled id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with icon 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-dimmed size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with icon and leading 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-dimmed size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with icon and trailing 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-11"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <span
-      class="absolute inset-y-0 end-0 flex items-center pe-3"
-      data-slot="trailing"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-dimmed size-5"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 pe-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
+    <span class="absolute end-0 flex inset-y-0 items-center pe-3" data-slot="trailing">
+      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </span>
   </div>
 </div>
@@ -144,69 +51,21 @@ exports[`Input > renders correctly with icon and trailing 1`] = `
 
 exports[`Input > renders correctly with id 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="id"
-      type="text"
-    />
-    <!--v-if-->
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="id" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with leading and trailing icons 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-dimmed size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11 pe-11"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <span
-      class="absolute inset-y-0 end-0 flex items-center pe-3"
-      data-slot="trailing"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-dimmed size-5"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 pe-11 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
+    <span class="absolute end-0 flex inset-y-0 items-center pe-3" data-slot="trailing">
+      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </span>
   </div>
 </div>
@@ -214,148 +73,54 @@ exports[`Input > renders correctly with leading and trailing icons 1`] = `
 
 exports[`Input > renders correctly with leading icon 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-dimmed size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with leading slot 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      Leading slot
-      
-    </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">Leading slot</span>
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1.5 px-2.5 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1.5 px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1 px-2 py-1 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1 px-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with trailing icon 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-11"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <span
-      class="absolute inset-y-0 end-0 flex items-center pe-3"
-      data-slot="trailing"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-dimmed size-5"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 pe-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
+    <span class="absolute end-0 flex inset-y-0 items-center pe-3" data-slot="trailing">
+      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </span>
   </div>
 </div>
@@ -363,114 +128,36 @@ exports[`Input > renders correctly with trailing icon 1`] = `
 
 exports[`Input > renders correctly with trailing slot 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-11"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <span
-      class="absolute inset-y-0 end-0 flex items-center pe-3"
-      data-slot="trailing"
-    >
-      
-      Trailing slot
-      
-    </span>
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 pe-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
+    <span class="absolute end-0 flex inset-y-0 items-center pe-3" data-slot="trailing">Trailing slot</span>
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <!--v-if-->
-    <input
-      class="w-full appearance-none border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset rounded-full"
-      data-slot="base"
-      id="v-0"
-      type="text"
-    />
-    <!--v-if-->
+  <div class="inline-flex items-center relative" data-slot="root">
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-full text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
 </div>
 `;
 
 exports[`Input > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <!--v-if-->
-        <input
-          aria-describedby="v-0-hint v-0-description v-0-help"
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          type="text"
-        />
-        <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <input aria-describedby="v-0-hint v-0-description v-0-help" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
       </div>
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/Input/__snapshots__/Input.spec.ts.snap
+++ b/packages/ui/src/components/Input/__snapshots__/Input.spec.ts.snap
@@ -20,7 +20,13 @@ exports[`Input > renders correctly with icon 1`] = `
 <div>
   <div class="inline-flex items-center relative" data-slot="root">
     <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
-      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+          <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+        </g>
+      </svg>
     </span>
     <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
@@ -31,7 +37,13 @@ exports[`Input > renders correctly with icon and leading 1`] = `
 <div>
   <div class="inline-flex items-center relative" data-slot="root">
     <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
-      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+          <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+        </g>
+      </svg>
     </span>
     <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
@@ -43,7 +55,13 @@ exports[`Input > renders correctly with icon and trailing 1`] = `
   <div class="inline-flex items-center relative" data-slot="root">
     <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 pe-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
     <span class="absolute end-0 flex inset-y-0 items-center pe-3" data-slot="trailing">
-      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+          <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+        </g>
+      </svg>
     </span>
   </div>
 </div>
@@ -61,11 +79,23 @@ exports[`Input > renders correctly with leading and trailing icons 1`] = `
 <div>
   <div class="inline-flex items-center relative" data-slot="root">
     <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
-      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+          <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+        </g>
+      </svg>
     </span>
     <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 pe-11 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
     <span class="absolute end-0 flex inset-y-0 items-center pe-3" data-slot="trailing">
-      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+          <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+        </g>
+      </svg>
     </span>
   </div>
 </div>
@@ -75,7 +105,13 @@ exports[`Input > renders correctly with leading icon 1`] = `
 <div>
   <div class="inline-flex items-center relative" data-slot="root">
     <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
-      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+          <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+        </g>
+      </svg>
     </span>
     <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
   </div>
@@ -120,7 +156,13 @@ exports[`Input > renders correctly with trailing icon 1`] = `
   <div class="inline-flex items-center relative" data-slot="root">
     <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 pe-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" type="text">
     <span class="absolute end-0 flex inset-y-0 items-center pe-3" data-slot="trailing">
-      <svg aria-hidden="true" class="shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5 text-dimmed" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09" />
+          <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05" />
+        </g>
+      </svg>
     </span>
   </div>
 </div>

--- a/packages/ui/src/components/InputColor/InputColor.spec.ts
+++ b/packages/ui/src/components/InputColor/InputColor.spec.ts
@@ -19,7 +19,7 @@ describe("InputColor", () => {
     const screen = page.render(InputColor, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -34,7 +34,7 @@ describe("InputColor", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/InputColor/__snapshots__/InputColor.spec.ts.snap
+++ b/packages/ui/src/components/InputColor/__snapshots__/InputColor.spec.ts.snap
@@ -2,426 +2,88 @@
 
 exports[`InputColor > renders correctly with class 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center w-64"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      
-      
-      <button
-        aria-controls=""
-        aria-disabled="false"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        class="inline-flex items-center justify-center transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-2 rounded-md"
-        data-slot="base"
-        data-state="closed"
-        id="reka-popover-trigger-v-1"
-        style="background-color: rgb(255, 0, 0);"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-      </button>
-      <!--teleport start-->
-      <!--teleport end-->
-      
-      
-      
+  <div class="inline-flex items-center relative w-64" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+      <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="dialog" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-slot="base" data-state="closed" id="reka-popover-trigger-v-1" type="button"></button>
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-      data-slot="base"
-      id="v-0"
-      maxlength="7"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" maxlength="7" type="text">
   </div>
 </div>
 `;
 
 exports[`InputColor > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      
-      
-      <button
-        aria-controls=""
-        aria-disabled="true"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        class="inline-flex items-center justify-center transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-2 rounded-md"
-        data-slot="base"
-        data-state="closed"
-        disabled=""
-        id="reka-popover-trigger-v-1"
-        style="background-color: rgb(255, 0, 0);"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-      </button>
-      <!--teleport start-->
-      <!--teleport end-->
-      
-      
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+      <button aria-controls aria-disabled="true" aria-expanded="false" aria-haspopup="dialog" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-slot="base" data-state="closed" disabled id="reka-popover-trigger-v-1" type="button"></button>
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-      data-slot="base"
-      disabled=""
-      id="v-0"
-      maxlength="7"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" disabled id="v-0" maxlength="7" type="text">
   </div>
 </div>
 `;
 
 exports[`InputColor > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      
-      
-      <button
-        aria-controls=""
-        aria-disabled="false"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        class="inline-flex items-center justify-center transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-2 rounded-md"
-        data-slot="base"
-        data-state="closed"
-        id="reka-popover-trigger-v-1"
-        style="background-color: rgb(255, 0, 0);"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-      </button>
-      <!--teleport start-->
-      <!--teleport end-->
-      
-      
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+      <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="dialog" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-slot="base" data-state="closed" id="reka-popover-trigger-v-1" type="button"></button>
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-      data-slot="base"
-      id="v-0"
-      maxlength="7"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" maxlength="7" type="text">
   </div>
 </div>
 `;
 
 exports[`InputColor > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-2.5"
-      data-slot="leading"
-    >
-      
-      
-      
-      <button
-        aria-controls=""
-        aria-disabled="false"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        class="inline-flex items-center justify-center transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1.5 rounded-sm"
-        data-slot="base"
-        data-state="closed"
-        id="reka-popover-trigger-v-1"
-        style="background-color: rgb(255, 0, 0);"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-      </button>
-      <!--teleport start-->
-      <!--teleport end-->
-      
-      
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-2.5 start-0" data-slot="leading">
+      <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="dialog" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1.5 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1.5 rounded-sm text-inverted text-sm transition-colors" data-slot="base" data-state="closed" id="reka-popover-trigger-v-1" type="button"></button>
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1.5 px-2.5 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-9"
-      data-slot="base"
-      id="v-0"
-      maxlength="7"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1.5 ps-9 px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" maxlength="7" type="text">
   </div>
 </div>
 `;
 
 exports[`InputColor > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-2"
-      data-slot="leading"
-    >
-      
-      
-      
-      <button
-        aria-controls=""
-        aria-disabled="false"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        class="inline-flex items-center justify-center transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-1 rounded-xs"
-        data-slot="base"
-        data-state="closed"
-        id="reka-popover-trigger-v-1"
-        style="background-color: rgb(255, 0, 0);"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-      </button>
-      <!--teleport start-->
-      <!--teleport end-->
-      
-      
-      
+  <div class="inline-flex items-center relative" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-2 start-0" data-slot="leading">
+      <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="dialog" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-1 rounded-xs text-inverted text-xs transition-colors" data-slot="base" data-state="closed" id="reka-popover-trigger-v-1" type="button"></button>
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1 px-2 py-1 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-7"
-      data-slot="base"
-      id="v-0"
-      maxlength="7"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1 ps-7 px-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" maxlength="7" type="text">
   </div>
 </div>
 `;
 
 exports[`InputColor > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center rounded-none"
-    data-slot="root"
-  >
-    <span
-      class="absolute inset-y-0 start-0 flex items-center ps-3"
-      data-slot="leading"
-    >
-      
-      
-      
-      <button
-        aria-controls=""
-        aria-disabled="false"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        class="inline-flex items-center justify-center transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-2 rounded-md"
-        data-slot="base"
-        data-state="closed"
-        id="reka-popover-trigger-v-1"
-        style="background-color: rgb(255, 0, 0);"
-        type="button"
-      >
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
-      </button>
-      <!--teleport start-->
-      <!--teleport end-->
-      
-      
-      
+  <div class="inline-flex items-center relative rounded-none" data-slot="root">
+    <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+      <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="dialog" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-slot="base" data-state="closed" id="reka-popover-trigger-v-1" type="button"></button>
     </span>
-    <input
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-      data-slot="base"
-      id="v-0"
-      maxlength="7"
-      type="text"
-    />
-    <!--v-if-->
+    <input class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" maxlength="7" type="text">
   </div>
 </div>
 `;
 
 exports[`InputColor > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <span
-          class="absolute inset-y-0 start-0 flex items-center ps-3"
-          data-slot="leading"
-        >
-          
-          
-          
-          <button
-            aria-controls=""
-            aria-disabled="false"
-            aria-expanded="false"
-            aria-haspopup="dialog"
-            class="inline-flex items-center justify-center transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary p-2 rounded-md"
-            data-slot="base"
-            data-state="closed"
-            id="reka-popover-trigger-v-1"
-            style="background-color: rgb(255, 0, 0);"
-            type="button"
-          >
-            
-            <!--v-if-->
-            
-            
-            <!--v-if-->
-            
-            
-            <!--v-if-->
-            
-          </button>
-          <!--teleport start-->
-          <!--teleport end-->
-          
-          
-          
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <span class="absolute flex inset-y-0 items-center ps-3 start-0" data-slot="leading">
+          <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="dialog" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center p-2 rounded-md text-base text-inverted transition-colors" data-slot="base" data-state="closed" id="reka-popover-trigger-v-1" type="button"></button>
         </span>
-        <input
-          aria-describedby="v-0-hint v-0-description v-0-help"
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset ps-11"
-          data-slot="base"
-          id="v-0"
-          maxlength="7"
-          type="text"
-        />
-        <!--v-if-->
+        <input aria-describedby="v-0-hint v-0-description v-0-help" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 ps-11 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" maxlength="7" type="text">
       </div>
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/InputDimensions/InputDimensions.spec.ts
+++ b/packages/ui/src/components/InputDimensions/InputDimensions.spec.ts
@@ -27,7 +27,7 @@ describe("InputDimensions", () => {
     const screen = page.render(InputDimensions, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/InputDimensions/__snapshots__/InputDimensions.spec.ts.snap
+++ b/packages/ui/src/components/InputDimensions/__snapshots__/InputDimensions.spec.ts.snap
@@ -10,17 +10,26 @@ exports[`InputDimensions > renders correctly with aspectRatio 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Unlock aspect ratio" aria-pressed="true" class="active:bg-primary/10 aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/10 hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-primary transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </g>
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -29,10 +38,14 @@ exports[`InputDimensions > renders correctly with aspectRatio 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -52,17 +65,23 @@ exports[`InputDimensions > renders correctly with class 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -71,10 +90,14 @@ exports[`InputDimensions > renders correctly with class 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -94,17 +117,23 @@ exports[`InputDimensions > renders correctly with disabled 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-disabled data-slot="base" disabled id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="true" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="true" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="true" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton" disabled>
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -113,10 +142,14 @@ exports[`InputDimensions > renders correctly with disabled 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-disabled data-slot="base" disabled id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="true" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="true" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -136,17 +169,23 @@ exports[`InputDimensions > renders correctly with heightFieldOptions 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper">
@@ -160,10 +199,14 @@ exports[`InputDimensions > renders correctly with heightFieldOptions 1`] = `
           <input aria-describedby="v-1-hint" aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -183,17 +226,23 @@ exports[`InputDimensions > renders correctly with heightInputOptions 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -202,10 +251,14 @@ exports[`InputDimensions > renders correctly with heightInputOptions 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -225,17 +278,23 @@ exports[`InputDimensions > renders correctly with orientation horizontal 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -244,10 +303,14 @@ exports[`InputDimensions > renders correctly with orientation horizontal 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -267,17 +330,23 @@ exports[`InputDimensions > renders correctly with orientation vertical 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="-translate-y-1/2 absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center left-0 p-2 rounded-md text-base text-default top-1/2 transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -286,10 +355,14 @@ exports[`InputDimensions > renders correctly with orientation vertical 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -309,17 +382,23 @@ exports[`InputDimensions > renders correctly with size lg 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -328,10 +407,14 @@ exports[`InputDimensions > renders correctly with size lg 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -351,17 +434,23 @@ exports[`InputDimensions > renders correctly with size md 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-8 ps-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-1.5 rounded-md self-end text-default text-sm transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-sm" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -370,10 +459,14 @@ exports[`InputDimensions > renders correctly with size md 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-8 ps-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -393,17 +486,23 @@ exports[`InputDimensions > renders correctly with size sm 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-7 ps-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-1 rounded-md self-end text-default text-xs transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-xs" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -412,10 +511,14 @@ exports[`InputDimensions > renders correctly with size sm 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-7 ps-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -435,17 +538,23 @@ exports[`InputDimensions > renders correctly with ui 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -454,10 +563,14 @@ exports[`InputDimensions > renders correctly with ui 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -482,17 +595,23 @@ exports[`InputDimensions > renders correctly with widthFieldOptions 1`] = `
           <input aria-describedby="v-0-hint" aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -501,10 +620,14 @@ exports[`InputDimensions > renders correctly with widthFieldOptions 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
@@ -524,17 +647,23 @@ exports[`InputDimensions > renders correctly with widthInputOptions 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
     <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
-      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07a5.006 5.006 0 0 0-6.95 0l-1.72 1.71m-6.58 6.57l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07a5.006 5.006 0 0 0 6.95 0l1.71-1.71M8 2v3M2 8h3m11 11v3m3-6h3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
     <div class="text-base" data-slot="root">
       <div class data-slot="wrapper"></div>
@@ -543,10 +672,14 @@ exports[`InputDimensions > renders correctly with widthInputOptions 1`] = `
           <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
           <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
             <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
             <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </button>
           </div>
         </div>

--- a/packages/ui/src/components/InputDimensions/__snapshots__/InputDimensions.spec.ts.snap
+++ b/packages/ui/src/components/InputDimensions/__snapshots__/InputDimensions.spec.ts.snap
@@ -2,243 +2,40 @@
 
 exports[`InputDimensions > renders correctly with aspectRatio 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Unlock aspect ratio"
-      aria-pressed="true"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-primary hover:bg-primary/10 focus-visible:outline-primary active:bg-primary/10 p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Unlock aspect ratio" aria-pressed="true" class="active:bg-primary/10 aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-2 hover:bg-primary/10 hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-primary transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -247,243 +44,40 @@ exports[`InputDimensions > renders correctly with aspectRatio 1`] = `
 
 exports[`InputDimensions > renders correctly with class 1`] = `
 <div>
-  <div
-    class="flex gap-2 w-64"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2 w-64" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -492,258 +86,40 @@ exports[`InputDimensions > renders correctly with class 1`] = `
 
 exports[`InputDimensions > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-disabled=""
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-disabled=""
-            data-slot="base"
-            disabled=""
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-disabled=""
-              data-slot="base"
-              disabled=""
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-disabled data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-disabled data-slot="base" disabled id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="true" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="true"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-disabled=""
-              data-slot="base"
-              disabled=""
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="true" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="true"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-      disabled=""
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="true" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton" disabled>
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-disabled=""
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-disabled=""
-            data-slot="base"
-            disabled=""
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-disabled=""
-              data-slot="base"
-              disabled=""
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-disabled data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-disabled data-slot="base" disabled id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="true" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="true"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-disabled=""
-              data-slot="base"
-              disabled=""
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="true" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -752,265 +128,45 @@ exports[`InputDimensions > renders correctly with disabled 1`] = `
 
 exports[`InputDimensions > renders correctly with heightFieldOptions 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <div
-          class="flex items-center justify-between gap-1"
-          data-slot="labelWrapper"
-        >
-          <label
-            class="block font-medium text-default"
-            data-slot="label"
-            for="v-1"
-            id="v-1-label"
-          >
-            
-            Height
-            
-          </label>
-          <span
-            class="text-muted"
-            data-slot="hint"
-            id="v-1-hint"
-          >
-            px
-          </span>
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper">
+        <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+          <label class="block font-medium text-default" data-slot="label" for="v-1" id="v-1-label">Height</label>
+          <span class="text-muted" data-slot="hint" id="v-1-hint">px</span>
         </div>
-        <!--v-if-->
       </div>
-      <div
-        class="mt-1"
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-describedby="v-1-hint"
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+      <div class="mt-1" data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-describedby="v-1-hint" aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -1019,244 +175,40 @@ exports[`InputDimensions > renders correctly with heightFieldOptions 1`] = `
 
 exports[`InputDimensions > renders correctly with heightInputOptions 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-    heightinputoptions="[object Object]"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root" heightinputoptions="[object Object]">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -1265,243 +217,40 @@ exports[`InputDimensions > renders correctly with heightInputOptions 1`] = `
 
 exports[`InputDimensions > renders correctly with orientation horizontal 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -1510,243 +259,40 @@ exports[`InputDimensions > renders correctly with orientation horizontal 1`] = `
 
 exports[`InputDimensions > renders correctly with orientation vertical 1`] = `
 <div>
-  <div
-    class="flex gap-2 relative flex-col pl-8"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex flex-col gap-2 pl-8 relative" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 absolute top-1/2 left-0 -translate-y-1/2"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="-translate-y-1/2 absolute active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center left-0 p-2 rounded-md text-base text-default top-1/2 transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -1755,243 +301,40 @@ exports[`InputDimensions > renders correctly with orientation vertical 1`] = `
 
 exports[`InputDimensions > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -2000,243 +343,40 @@ exports[`InputDimensions > renders correctly with size lg 1`] = `
 
 exports[`InputDimensions > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-  >
-    <div
-      class="text-sm"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1.5 ps-2.5 pe-8 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1.5"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-4"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root">
+    <div class="text-sm" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-8 ps-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1.5"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-4"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-1.5 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-4"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-1.5 rounded-md self-end text-default text-sm transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-sm"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1.5 ps-2.5 pe-8 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1.5"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-4"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-sm" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-8 ps-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1.5"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-4"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -2245,243 +385,40 @@ exports[`InputDimensions > renders correctly with size md 1`] = `
 
 exports[`InputDimensions > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-  >
-    <div
-      class="text-xs"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1 ps-2 pe-7 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-3"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root">
+    <div class="text-xs" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-7 ps-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-3"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1 text-xs text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-1 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-3"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-1 rounded-md self-end text-default text-xs transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-xs"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1 ps-2 pe-7 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-3"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-xs" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-7 ps-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-3"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -2490,243 +427,40 @@ exports[`InputDimensions > renders correctly with size sm 1`] = `
 
 exports[`InputDimensions > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="flex gap-4"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-4" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -2735,265 +469,45 @@ exports[`InputDimensions > renders correctly with ui 1`] = `
 
 exports[`InputDimensions > renders correctly with widthFieldOptions 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <div
-          class="flex items-center justify-between gap-1"
-          data-slot="labelWrapper"
-        >
-          <label
-            class="block font-medium text-default"
-            data-slot="label"
-            for="v-0"
-            id="v-0-label"
-          >
-            
-            Width
-            
-          </label>
-          <span
-            class="text-muted"
-            data-slot="hint"
-            id="v-0-hint"
-          >
-            px
-          </span>
+  <div class="flex gap-2" data-slot="root">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper">
+        <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+          <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Width</label>
+          <span class="text-muted" data-slot="hint" id="v-0-hint">px</span>
         </div>
-        <!--v-if-->
       </div>
-      <div
-        class="mt-1"
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-describedby="v-0-hint"
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+      <div class="mt-1" data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-describedby="v-0-hint" aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>
@@ -3002,244 +516,40 @@ exports[`InputDimensions > renders correctly with widthFieldOptions 1`] = `
 
 exports[`InputDimensions > renders correctly with widthInputOptions 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-slot="root"
-    widthinputoptions="[object Object]"
-  >
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+  <div class="flex gap-2" data-slot="root" widthinputoptions="[object Object]">
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      aria-label="Lock aspect ratio"
-      aria-pressed="false"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated p-2 mb-0.5 self-end"
-      data-slot="lockButton"
-    >
-      
-      <svg
-        aria-hidden="true"
-        class="shrink-0 size-5"
-        data-slot="leadingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
-      
-      <!--v-if-->
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-label="Lock aspect ratio" aria-pressed="false" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center mb-0.5 p-2 rounded-md self-end text-base text-default transition-colors" data-slot="lockButton">
+      <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <div
-      class="text-base"
-      data-slot="root"
-    >
-      <div
-        class=""
-        data-slot="wrapper"
-      >
-        <!--v-if-->
-        <!--v-if-->
-      </div>
-      <div
-        class=""
-        data-slot="container"
-      >
-        
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-            data-slot="base"
-            id="v-1"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <div
-            class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-            data-slot="buttons"
-          >
-            <button
-              aria-disabled="false"
-              aria-label="Increment"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+    <div class="text-base" data-slot="root">
+      <div class data-slot="wrapper"></div>
+      <div class data-slot="container">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-1" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+          <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+            <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
-            <button
-              aria-disabled="false"
-              aria-label="Decrement"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-              data-slot="base"
-              tabindex="-1"
-              type="button"
-            >
-              
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="leadingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-              
-              
-              <!--v-if-->
-              
-              
-              <!--v-if-->
-              
+            <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </button>
           </div>
-          
-          <!--v-if-->
         </div>
-        
-        <!--v-if-->
       </div>
     </div>
   </div>

--- a/packages/ui/src/components/InputNumber/InputNumber.spec.ts
+++ b/packages/ui/src/components/InputNumber/InputNumber.spec.ts
@@ -28,7 +28,7 @@ describe("InputNumber", () => {
     const screen = page.render(InputNumber, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -43,7 +43,7 @@ describe("InputNumber", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/InputNumber/__snapshots__/InputNumber.spec.ts.snap
+++ b/packages/ui/src/components/InputNumber/__snapshots__/InputNumber.spec.ts.snap
@@ -6,10 +6,14 @@ exports[`InputNumber > renders correctly with class 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -22,10 +26,14 @@ exports[`InputNumber > renders correctly with disabled 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-disabled data-slot="base" disabled id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="true" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="true" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -38,10 +46,14 @@ exports[`InputNumber > renders correctly with id 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="id" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -54,10 +66,14 @@ exports[`InputNumber > renders correctly with min and max 1`] = `
     <input aria-roledescription="Number field" aria-valuemax="100" aria-valuemin="0" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -70,10 +86,14 @@ exports[`InputNumber > renders correctly with size lg 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -86,10 +106,14 @@ exports[`InputNumber > renders correctly with size md 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-8 ps-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -102,10 +126,14 @@ exports[`InputNumber > renders correctly with size sm 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-7 ps-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -118,10 +146,14 @@ exports[`InputNumber > renders correctly with step 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -134,10 +166,14 @@ exports[`InputNumber > renders correctly with ui 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-full text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -150,10 +186,14 @@ exports[`InputNumber > renders correctly with variant outline 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-default border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -166,10 +206,14 @@ exports[`InputNumber > renders correctly with variant subtle 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -191,10 +235,14 @@ exports[`InputNumber > renders correctly within FormField 1`] = `
         <input aria-describedby="v-0-hint v-0-description v-0-help" aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
         <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
           <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-            <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+            <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+            </svg>
           </button>
           <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-            <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+            <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+            </svg>
           </button>
         </div>
       </div>
@@ -210,7 +258,9 @@ exports[`InputNumber > renders correctly without decrement 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>
@@ -223,7 +273,9 @@ exports[`InputNumber > renders correctly without increment 1`] = `
     <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
       <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
       </button>
     </div>
   </div>

--- a/packages/ui/src/components/InputNumber/__snapshots__/InputNumber.spec.ts.snap
+++ b/packages/ui/src/components/InputNumber/__snapshots__/InputNumber.spec.ts.snap
@@ -2,1130 +2,203 @@
 
 exports[`InputNumber > renders correctly with class 1`] = `
 <div>
-  <div
-    class="inline-flex items-center absolute"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="absolute inline-flex items-center" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-disabled=""
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-disabled=""
-      data-slot="base"
-      disabled=""
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="true"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-disabled=""
-        data-slot="base"
-        disabled=""
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-disabled data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-disabled data-slot="base" disabled id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="true" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="true"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-disabled=""
-        data-slot="base"
-        disabled=""
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="true" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-disabled data-slot="base" disabled tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with id 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="id"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="id" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with min and max 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" aria-valuemax="100" aria-valuemin="0" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1.5 ps-2.5 pe-8 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1.5"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-4"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-8 ps-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1.5"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-4"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1.5 rounded-md text-muted text-sm transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1 ps-2 pe-7 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-3"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-7 ps-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 text-xs text-muted hover:text-default focus-visible:outline-inverted active:text-default p-1"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-3"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-1 rounded-md text-muted text-xs transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-3" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with step 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset rounded-full"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-full text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with variant outline 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-default ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-default border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly with variant subtle 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-        role="group"
-      >
-        
-        <input
-          aria-describedby="v-0-hint v-0-description v-0-help"
-          aria-roledescription="Number field"
-          autocomplete="off"
-          autocorrect="off"
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          inputmode="decimal"
-          role="spinbutton"
-          spellcheck="false"
-          tabindex="0"
-          type="text"
-          value=""
-        />
-        <div
-          class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-          data-slot="buttons"
-        >
-          <button
-            aria-disabled="false"
-            aria-label="Increment"
-            class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-            data-slot="base"
-            tabindex="-1"
-            type="button"
-          >
-            
-            <svg
-              aria-hidden="true"
-              class="shrink-0 size-5"
-              data-slot="leadingIcon"
-              height="1em"
-              role="img"
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            />
-            
-            
-            <!--v-if-->
-            
-            
-            <!--v-if-->
-            
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root" role="group">
+        <input aria-describedby="v-0-hint v-0-description v-0-help" aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+        <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+          <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+            <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
           </button>
-          <button
-            aria-disabled="false"
-            aria-label="Decrement"
-            class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-            data-slot="base"
-            tabindex="-1"
-            type="button"
-          >
-            
-            <svg
-              aria-hidden="true"
-              class="shrink-0 size-5"
-              data-slot="leadingIcon"
-              height="1em"
-              role="img"
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            />
-            
-            
-            <!--v-if-->
-            
-            
-            <!--v-if-->
-            
+          <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+            <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
           </button>
         </div>
-        
-        <!--v-if-->
       </div>
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>
@@ -1133,153 +206,34 @@ exports[`InputNumber > renders correctly within FormField 1`] = `
 
 exports[`InputNumber > renders correctly without decrement 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Increment"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
-      <!--v-if-->
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly without increment 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <div
-      class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-      data-slot="buttons"
-    >
-      <!--v-if-->
-      <button
-        aria-disabled="false"
-        aria-label="Decrement"
-        class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-        data-slot="base"
-        tabindex="-1"
-        type="button"
-      >
-        
-        <svg
-          aria-hidden="true"
-          class="shrink-0 size-5"
-          data-slot="leadingIcon"
-          height="1em"
-          role="img"
-          viewBox="0 0 16 16"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        />
-        
-        
-        <!--v-if-->
-        
-        
-        <!--v-if-->
-        
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+    <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+      <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+        <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
       </button>
     </div>
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`InputNumber > renders correctly without increment and decrement 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-    role="group"
-  >
-    
-    <input
-      aria-roledescription="Number field"
-      autocomplete="off"
-      autocorrect="off"
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-      data-slot="base"
-      id="v-0"
-      inputmode="decimal"
-      role="spinbutton"
-      spellcheck="false"
-      tabindex="0"
-      type="text"
-      value=""
-    />
-    <!--v-if-->
-    
-    <!--v-if-->
+  <div class="inline-flex items-center relative" data-slot="root" role="group">
+    <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
   </div>
 </div>
 `;

--- a/packages/ui/src/components/InputNumberSlider/InputNumberSlider.spec.ts
+++ b/packages/ui/src/components/InputNumberSlider/InputNumberSlider.spec.ts
@@ -39,7 +39,7 @@ describe("InputNumberSlider", () => {
     const screen = page.render(Wrapper, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -54,7 +54,7 @@ describe("InputNumberSlider", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/InputNumberSlider/__snapshots__/InputNumberSlider.spec.ts.snap
+++ b/packages/ui/src/components/InputNumberSlider/__snapshots__/InputNumberSlider.spec.ts.snap
@@ -2,1339 +2,237 @@
 
 exports[`InputNumberSlider > renders correctly with class 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2 w-64"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-x-2 items-center w-64" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with decrement 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <div
-        class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-        data-slot="buttons"
-      >
-        <!--v-if-->
-        <button
-          aria-disabled="false"
-          aria-label="Decrement"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-          data-slot="base"
-          tabindex="-1"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-5"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+      <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+        <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
       </div>
-      
-      <!--v-if-->
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with disabled 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-disabled=""
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-        data-disabled=""
-        data-slot="base"
-        disabled=""
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-disabled data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-disabled data-slot="base" disabled id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="true"
-      class="relative flex touch-none items-center select-none cursor-not-allowed opacity-75 w-full"
-      data-disabled=""
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-disabled=""
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-disabled=""
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="true" class="cursor-not-allowed flex items-center opacity-75 relative select-none touch-none w-full" data-disabled data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-disabled data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-disabled data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5 cursor-not-allowed"
-        data-disabled=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-disabled data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with increment 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <div
-        class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-        data-slot="buttons"
-      >
-        <button
-          aria-disabled="false"
-          aria-label="Increment"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-          data-slot="base"
-          tabindex="-1"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-5"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+      <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+        <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <!--v-if-->
       </div>
-      
-      <!--v-if-->
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with increment and decrement 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 pe-9 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <div
-        class="absolute inset-y-0 end-0 flex flex-col justify-center [&>button]:scale-80 [&>button]:py-0 pe-1.5"
-        data-slot="buttons"
-      >
-        <button
-          aria-disabled="false"
-          aria-label="Increment"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-          data-slot="base"
-          tabindex="-1"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-5"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
+      <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
+        <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <button
-          aria-disabled="false"
-          aria-label="Decrement"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-2 text-base text-muted hover:text-default focus-visible:outline-inverted active:text-default p-2"
-          data-slot="base"
-          tabindex="-1"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-5"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
       </div>
-      
-      <!--v-if-->
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with min and max 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        aria-valuemax="50"
-        aria-valuemin="0"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" aria-valuemax="50" aria-valuemin="0" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="50"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="50" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with size lg 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with size md 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1.5 ps-2.5 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-2.5"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-2.5 ps-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-4"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-4" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with size sm 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-1 ps-2 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-2"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-2 ps-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-1.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-1.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-3"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-3" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with step 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with tooltip 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-x-2"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-x-2 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      
-      
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-grace-area-trigger=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        data-state="closed"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      <!--teleport start-->
-      <!--teleport end-->
-      
-      
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-grace-area-trigger data-orientation="horizontal" data-reka-collection-item data-slot="thumb" data-state="closed" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly with ui 1`] = `
 <div>
-  
-  <div
-    class="flex items-center gap-4"
-    data-slot="root"
-  >
-    <div
-      class="relative inline-flex items-center"
-      data-slot="root"
-      role="group"
-    >
-      
-      <input
-        aria-roledescription="Number field"
-        autocomplete="off"
-        autocorrect="off"
-        class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-        data-slot="base"
-        id="v-0"
-        inputmode="decimal"
-        role="spinbutton"
-        spellcheck="false"
-        tabindex="0"
-        type="text"
-        value=""
-      />
-      <!--v-if-->
-      
-      <!--v-if-->
+  <div class="flex gap-4 items-center" data-slot="root">
+    <div class="inline-flex items-center relative" data-slot="root" role="group">
+      <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
     </div>
-    <span
-      aria-disabled="false"
-      class="relative flex touch-none items-center select-none w-full"
-      data-orientation="horizontal"
-      data-slider-impl=""
-      data-slot="root"
-      dir="ltr"
-      id="v-1"
-      style="--reka-slider-thumb-transform: translateX(-50%);"
-    >
-      
-      
-      
-      <span
-        class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-        data-orientation="horizontal"
-        data-slot="track"
-      >
-        
-        <span
-          class="absolute h-full rounded-full bg-primary"
-          data-orientation="horizontal"
-          data-slot="range"
-          style="left: 0%; right: 100%;"
-        >
-          
-          
-        </span>
-        
+    <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+      <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+        <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
       </span>
-      <span
-        aria-label="Thumb"
-        aria-orientation="horizontal"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="0"
-        class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="thumb"
-        role="slider"
-        style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-        tabindex="0"
-      >
-        
-        
-      </span>
-      
-      <!--v-if-->
-      
-      
+      <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
     </span>
   </div>
-  
 </div>
 `;
 
 exports[`InputNumberSlider > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        aria-describedby="v-0-hint v-0-description v-0-help"
-        aria-labelledby="v-0-label"
-        class="flex items-center gap-x-2"
-        data-slot="root"
-        role="group"
-      >
-        <div
-          class="relative inline-flex items-center"
-          data-slot="root"
-          role="group"
-        >
-          
-          <input
-            aria-roledescription="Number field"
-            autocomplete="off"
-            autocorrect="off"
-            class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset py-2 ps-3 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset pe-3"
-            data-slot="base"
-            id="v-0"
-            inputmode="decimal"
-            role="spinbutton"
-            spellcheck="false"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-          <!--v-if-->
-          
-          <!--v-if-->
+    <div class="mt-1" data-slot="container">
+      <div aria-describedby="v-0-hint v-0-description v-0-help" aria-labelledby="v-0-label" class="flex gap-x-2 items-center" data-slot="root" role="group">
+        <div class="inline-flex items-center relative" data-slot="root" role="group">
+          <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-3 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
         </div>
-        <span
-          aria-disabled="false"
-          class="relative flex touch-none items-center select-none w-full"
-          data-orientation="horizontal"
-          data-slider-impl=""
-          data-slot="root"
-          dir="ltr"
-          id="v-1"
-          style="--reka-slider-thumb-transform: translateX(-50%);"
-        >
-          
-          
-          
-          <span
-            class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-            data-orientation="horizontal"
-            data-slot="track"
-          >
-            
-            <span
-              class="absolute h-full rounded-full bg-primary"
-              data-orientation="horizontal"
-              data-slot="range"
-              style="left: 0%; right: 100%;"
-            >
-              
-              
-            </span>
-            
+        <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-1">
+          <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+            <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
           </span>
-          <span
-            aria-label="Thumb"
-            aria-orientation="horizontal"
-            aria-valuemax="100"
-            aria-valuemin="0"
-            aria-valuenow="0"
-            class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-            data-orientation="horizontal"
-            data-reka-collection-item=""
-            data-slot="thumb"
-            role="slider"
-            style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-            tabindex="0"
-          >
-            
-            
-          </span>
-          
-          <!--v-if-->
-          
-          
+          <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
         </span>
       </div>
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/InputNumberSlider/__snapshots__/InputNumberSlider.spec.ts.snap
+++ b/packages/ui/src/components/InputNumberSlider/__snapshots__/InputNumberSlider.spec.ts.snap
@@ -23,7 +23,9 @@ exports[`InputNumberSlider > renders correctly with decrement 1`] = `
       <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
       <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
         <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
       </div>
     </div>
@@ -60,7 +62,9 @@ exports[`InputNumberSlider > renders correctly with increment 1`] = `
       <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
       <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
         <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
       </div>
     </div>
@@ -81,10 +85,14 @@ exports[`InputNumberSlider > renders correctly with increment and decrement 1`] 
       <input aria-roledescription="Number field" autocomplete="off" autocorrect="off" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none pe-9 ps-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" inputmode="decimal" role="spinbutton" spellcheck="false" tabindex="0" type="text" value>
       <div class="[&amp;&gt;button]:py-0 [&amp;&gt;button]:scale-80 absolute end-0 flex flex-col inset-y-0 justify-center pe-1.5" data-slot="buttons">
         <button aria-disabled="false" aria-label="Increment" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="m18 15l-6-6l-6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <button aria-disabled="false" aria-label="Decrement" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-2 rounded-md text-base text-muted transition-colors" data-slot="base" tabindex="-1" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
       </div>
     </div>

--- a/packages/ui/src/components/Kbd/Kbd.spec.ts
+++ b/packages/ui/src/components/Kbd/Kbd.spec.ts
@@ -17,6 +17,6 @@ describe("Kbd", () => {
     const screen = page.render(Kbd, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Kbd/__snapshots__/Kbd.spec.ts.snap
+++ b/packages/ui/src/components/Kbd/__snapshots__/Kbd.spec.ts.snap
@@ -2,66 +2,36 @@
 
 exports[`Kbd > renders correctly with as 1`] = `
 <div>
-  <span
-    class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-5 min-w-5 text-[11px]"
-    data-slot="base"
-  >
-    K
-  </span>
+  <span class="bg-default font-medium font-sans h-5 inline-flex items-center justify-center min-w-5 px-1 ring ring-accented ring-inset rounded-sm text-[11px] text-default" data-slot="base">K</span>
 </div>
 `;
 
 exports[`Kbd > renders correctly with class 1`] = `
 <div>
-  <kbd
-    class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans text-default ring ring-accented ring-inset h-5 min-w-5 text-[11px] font-bold"
-    data-slot="base"
-  >
-    K
-  </kbd>
+  <kbd class="bg-default font-bold font-sans h-5 inline-flex items-center justify-center min-w-5 px-1 ring ring-accented ring-inset rounded-sm text-[11px] text-default" data-slot="base">K</kbd>
 </div>
 `;
 
 exports[`Kbd > renders correctly with size lg 1`] = `
 <div>
-  <kbd
-    class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-6 min-w-6 text-[12px]"
-    data-slot="base"
-  >
-    K
-  </kbd>
+  <kbd class="bg-default font-medium font-sans h-6 inline-flex items-center justify-center min-w-6 px-1 ring ring-accented ring-inset rounded-sm text-[12px] text-default" data-slot="base">K</kbd>
 </div>
 `;
 
 exports[`Kbd > renders correctly with size md 1`] = `
 <div>
-  <kbd
-    class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-5 min-w-5 text-[11px]"
-    data-slot="base"
-  >
-    K
-  </kbd>
+  <kbd class="bg-default font-medium font-sans h-5 inline-flex items-center justify-center min-w-5 px-1 ring ring-accented ring-inset rounded-sm text-[11px] text-default" data-slot="base">K</kbd>
 </div>
 `;
 
 exports[`Kbd > renders correctly with size sm 1`] = `
 <div>
-  <kbd
-    class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-    data-slot="base"
-  >
-    K
-  </kbd>
+  <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">K</kbd>
 </div>
 `;
 
 exports[`Kbd > renders correctly with value 1`] = `
 <div>
-  <kbd
-    class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-5 min-w-5 text-[11px]"
-    data-slot="base"
-  >
-    K
-  </kbd>
+  <kbd class="bg-default font-medium font-sans h-5 inline-flex items-center justify-center min-w-5 px-1 ring ring-accented ring-inset rounded-sm text-[11px] text-default" data-slot="base">K</kbd>
 </div>
 `;

--- a/packages/ui/src/components/Menubar/Menubar.spec.ts
+++ b/packages/ui/src/components/Menubar/Menubar.spec.ts
@@ -74,6 +74,6 @@ describe("Menubar", () => {
     await userEvent.click(trigger);
 
     await nextTick();
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Menubar/__snapshots__/Menubar.spec.ts.snap
+++ b/packages/ui/src/components/Menubar/__snapshots__/Menubar.spec.ts.snap
@@ -2,2216 +2,327 @@
 
 exports[`Menubar > renders correctly with checkbox menus 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-controls="reka-menubar-content-v-2"
-      aria-disabled="false"
-      aria-expanded="true"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-highlighted=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="open"
-      data-value="reka-v-0"
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="0"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        View
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="0">
+    <button aria-controls="reka-menubar-content-v-2" aria-disabled="false" aria-expanded="true" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-highlighted data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="open" data-value="reka-v-0" id="reka-v-0" role="menuitem" tabindex="0" type="button">
+      <span class="truncate" data-slot="label">View</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <div
-      data-reka-popper-content-wrapper=""
-      style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 40px); min-width: max-content; --reka-popper-transform-origin: 0% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 848px; --reka-popper-anchor-width: 49.525001525878906px; --reka-popper-anchor-height: 32px;"
-    >
-      <div
-        aria-labelledby="reka-v-0"
-        aria-orientation="vertical"
-        class="pointer-events-auto min-w-32 origin-(--reka-menubar-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-        data-align="start"
-        data-dismissable-layer=""
-        data-orientation="vertical"
-        data-reka-menu-content=""
-        data-reka-menubar-content=""
-        data-side="bottom"
-        data-slot="content"
-        data-state="open"
-        dir="ltr"
-        id="reka-menubar-content-v-2"
-        role="menu"
-        style="--reka-menubar-content-transform-origin: var(--reka-popper-transform-origin); --reka-menubar-content-available-width: var(--reka-popper-available-width); --reka-menubar-content-available-height: var(--reka-popper-available-height); --reka-menubar-trigger-width: var(--reka-popper-anchor-width); --reka-menubar-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-        tabindex="-1"
-      >
-        
-        
-        
-        
-        
-        
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="flex w-full items-center font-semibold gap-1.5 p-1.5 text-sm"
-            data-slot="label"
-          >
-            
-            
-            Display
-            
-            
+    <div data-reka-popper-content-wrapper>
+      <div aria-labelledby="reka-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-menubar-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-reka-menubar-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-menubar-content-v-2" role="menu" tabindex="-1">
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="flex font-semibold gap-1.5 items-center p-1.5 text-sm w-full" data-slot="label">Display</div>
+          <div aria-orientation="horizontal" class="-mx-1 bg-border h-px my-1" data-slot="separator" role="separator"></div>
+          <div aria-checked="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="checked" role="menuitemcheckbox" tabindex="-1">
+            <span class="truncate" data-slot="itemLabel">Show Grid</span>
+            <svg aria-hidden="true" class="inline-flex items-center ms-auto shrink-0 size-5" data-slot="itemTrailingIcon" data-state="checked" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
           </div>
-          
-          
-          <div
-            aria-orientation="horizontal"
-            class="-mx-1 my-1 h-px bg-border"
-            data-slot="separator"
-            role="separator"
-          >
-            
-            
+          <div aria-checked="false" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="unchecked" role="menuitemcheckbox" tabindex="-1">
+            <span class="truncate" data-slot="itemLabel">Show Rulers</span>
           </div>
-          
-          
-          <div
-            aria-checked="true"
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            data-state="checked"
-            role="menuitemcheckbox"
-            tabindex="-1"
-          >
-            
-            
-            
-            
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Show Grid
-            </span>
-            <svg
-              aria-hidden="true"
-              class="ms-auto inline-flex items-center shrink-0 size-5"
-              data-slot="itemTrailingIcon"
-              data-state="checked"
-              height="1em"
-              role="img"
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            />
-            
-            
-            
-            
-          </div>
-          
-          
-          <div
-            aria-checked="false"
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            data-state="unchecked"
-            role="menuitemcheckbox"
-            tabindex="-1"
-          >
-            
-            
-            
-            
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              Show Rulers
-            </span>
-            <!---->
-            
-            
-            
-            
-          </div>
-          
-          
-          
-          
         </div>
-        
-        
-        
-        
-        
-        
       </div>
     </div>
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;
 
 exports[`Menubar > renders correctly with class 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-controls="reka-menubar-content-v-4"
-      aria-disabled="false"
-      aria-expanded="true"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-highlighted=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="open"
-      data-value="reka-v-0"
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="0"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        File
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="0">
+    <button aria-controls="reka-menubar-content-v-4" aria-disabled="false" aria-expanded="true" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-highlighted data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="open" data-value="reka-v-0" id="reka-v-0" role="menuitem" tabindex="0" type="button">
+      <span class="truncate" data-slot="label">File</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <div
-      data-reka-popper-content-wrapper=""
-      style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 40px); min-width: max-content; --reka-popper-transform-origin: 0% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 848px; --reka-popper-anchor-width: 40.95000076293945px; --reka-popper-anchor-height: 32px;"
-    >
-      <div
-        aria-labelledby="reka-v-0"
-        aria-orientation="vertical"
-        class="pointer-events-auto origin-(--reka-menubar-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] min-w-48"
-        data-align="start"
-        data-dismissable-layer=""
-        data-orientation="vertical"
-        data-reka-menu-content=""
-        data-reka-menubar-content=""
-        data-side="bottom"
-        data-slot="content"
-        data-state="open"
-        dir="ltr"
-        id="reka-menubar-content-v-4"
-        role="menu"
-        style="--reka-menubar-content-transform-origin: var(--reka-popper-transform-origin); --reka-menubar-content-available-width: var(--reka-popper-available-width); --reka-menubar-content-available-height: var(--reka-popper-available-height); --reka-menubar-trigger-width: var(--reka-popper-anchor-width); --reka-menubar-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-        tabindex="-1"
-      >
-        
-        
-        
-        
-        
-        
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                New
-              </span>
-              <!--v-if-->
+    <div data-reka-popper-content-wrapper>
+      <div aria-labelledby="reka-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-48 origin-(--reka-menubar-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-reka-menubar-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-menubar-content-v-4" role="menu" tabindex="-1">
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">New</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+N
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+N</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Open
-              </span>
-              <!--v-if-->
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Open</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+O
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+O</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Save
-              </span>
-              <!--v-if-->
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Save</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+S
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+S</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        
-        
-        
-        
-        
-        
       </div>
     </div>
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
-    <button
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="closed"
-      data-value="reka-v-2"
-      id="reka-v-2"
-      role="menuitem"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Edit
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-expanded="false" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="closed" data-value="reka-v-2" id="reka-v-2" role="menuitem" tabindex="-1" type="button">
+      <span class="truncate" data-slot="label">Edit</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <!---->
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;
 
 exports[`Menubar > renders correctly with disabled menu 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="-1"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-disabled="true"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-disabled=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="closed"
-      data-value="reka-v-0"
-      disabled=""
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        File
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="-1">
+    <button aria-disabled="true" aria-expanded="false" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-disabled data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="closed" data-value="reka-v-0" disabled id="reka-v-0" role="menuitem" tabindex="-1" type="button">
+      <span class="truncate" data-slot="label">File</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <!---->
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;
 
 exports[`Menubar > renders correctly with simple menus 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-controls="reka-menubar-content-v-4"
-      aria-disabled="false"
-      aria-expanded="true"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-highlighted=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="open"
-      data-value="reka-v-0"
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="0"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        File
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="0">
+    <button aria-controls="reka-menubar-content-v-4" aria-disabled="false" aria-expanded="true" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-highlighted data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="open" data-value="reka-v-0" id="reka-v-0" role="menuitem" tabindex="0" type="button">
+      <span class="truncate" data-slot="label">File</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <div
-      data-reka-popper-content-wrapper=""
-      style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 40px); min-width: max-content; --reka-popper-transform-origin: 0% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 848px; --reka-popper-anchor-width: 40.95000076293945px; --reka-popper-anchor-height: 32px;"
-    >
-      <div
-        aria-labelledby="reka-v-0"
-        aria-orientation="vertical"
-        class="pointer-events-auto min-w-32 origin-(--reka-menubar-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-        data-align="start"
-        data-dismissable-layer=""
-        data-orientation="vertical"
-        data-reka-menu-content=""
-        data-reka-menubar-content=""
-        data-side="bottom"
-        data-slot="content"
-        data-state="open"
-        dir="ltr"
-        id="reka-menubar-content-v-4"
-        role="menu"
-        style="--reka-menubar-content-transform-origin: var(--reka-popper-transform-origin); --reka-menubar-content-available-width: var(--reka-popper-available-width); --reka-menubar-content-available-height: var(--reka-popper-available-height); --reka-menubar-trigger-width: var(--reka-popper-anchor-width); --reka-menubar-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-        tabindex="-1"
-      >
-        
-        
-        
-        
-        
-        
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                New
-              </span>
-              <!--v-if-->
+    <div data-reka-popper-content-wrapper>
+      <div aria-labelledby="reka-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-menubar-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-reka-menubar-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-menubar-content-v-4" role="menu" tabindex="-1">
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">New</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+N
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+N</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Open
-              </span>
-              <!--v-if-->
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Open</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+O
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+O</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Save
-              </span>
-              <!--v-if-->
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Save</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+S
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+S</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        
-        
-        
-        
-        
-        
       </div>
     </div>
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
-    <button
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="closed"
-      data-value="reka-v-2"
-      id="reka-v-2"
-      role="menuitem"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Edit
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-expanded="false" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="closed" data-value="reka-v-2" id="reka-v-2" role="menuitem" tabindex="-1" type="button">
+      <span class="truncate" data-slot="label">Edit</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <!---->
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;
 
 exports[`Menubar > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-controls="reka-menubar-content-v-4"
-      aria-disabled="false"
-      aria-expanded="true"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 px-3 py-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-highlighted=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="open"
-      data-value="reka-v-0"
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="0"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        File
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="0">
+    <button aria-controls="reka-menubar-content-v-4" aria-disabled="false" aria-expanded="true" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-3 py-2 rounded-md text-base text-default transition-colors" data-highlighted data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="open" data-value="reka-v-0" id="reka-v-0" role="menuitem" tabindex="0" type="button">
+      <span class="truncate" data-slot="label">File</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <div
-      data-reka-popper-content-wrapper=""
-      style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 48px); min-width: max-content; --reka-popper-transform-origin: 0% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 840px; --reka-popper-anchor-width: 47.9375px; --reka-popper-anchor-height: 40px;"
-    >
-      <div
-        aria-labelledby="reka-v-0"
-        aria-orientation="vertical"
-        class="pointer-events-auto min-w-32 origin-(--reka-menubar-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-        data-align="start"
-        data-dismissable-layer=""
-        data-orientation="vertical"
-        data-reka-menu-content=""
-        data-reka-menubar-content=""
-        data-side="bottom"
-        data-slot="content"
-        data-state="open"
-        dir="ltr"
-        id="reka-menubar-content-v-4"
-        role="menu"
-        style="--reka-menubar-content-transform-origin: var(--reka-popper-transform-origin); --reka-menubar-content-available-width: var(--reka-popper-available-width); --reka-menubar-content-available-height: var(--reka-popper-available-height); --reka-menubar-trigger-width: var(--reka-popper-anchor-width); --reka-menubar-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-        tabindex="-1"
-      >
-        
-        
-        
-        
-        
-        
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                New
-              </span>
-              <!--v-if-->
+    <div data-reka-popper-content-wrapper>
+      <div aria-labelledby="reka-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-menubar-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-reka-menubar-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-menubar-content-v-4" role="menu" tabindex="-1">
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">New</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+N
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+N</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Open
-              </span>
-              <!--v-if-->
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Open</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+O
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+O</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-2 p-2 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Save
-              </span>
-              <!--v-if-->
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-2 group items-center outline-none p-2 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Save</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+S
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+S</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        
-        
-        
-        
-        
-        
       </div>
     </div>
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
-    <button
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-2 px-3 py-2 text-base text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="closed"
-      data-value="reka-v-2"
-      id="reka-v-2"
-      role="menuitem"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Edit
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-expanded="false" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-2 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-3 py-2 rounded-md text-base text-default transition-colors" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="closed" data-value="reka-v-2" id="reka-v-2" role="menuitem" tabindex="-1" type="button">
+      <span class="truncate" data-slot="label">Edit</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <!---->
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;
 
 exports[`Menubar > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-controls="reka-menubar-content-v-4"
-      aria-disabled="false"
-      aria-expanded="true"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-highlighted=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="open"
-      data-value="reka-v-0"
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="0"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        File
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="0">
+    <button aria-controls="reka-menubar-content-v-4" aria-disabled="false" aria-expanded="true" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-highlighted data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="open" data-value="reka-v-0" id="reka-v-0" role="menuitem" tabindex="0" type="button">
+      <span class="truncate" data-slot="label">File</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <div
-      data-reka-popper-content-wrapper=""
-      style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 40px); min-width: max-content; --reka-popper-transform-origin: 0% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 848px; --reka-popper-anchor-width: 40.95000076293945px; --reka-popper-anchor-height: 32px;"
-    >
-      <div
-        aria-labelledby="reka-v-0"
-        aria-orientation="vertical"
-        class="pointer-events-auto min-w-32 origin-(--reka-menubar-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-        data-align="start"
-        data-dismissable-layer=""
-        data-orientation="vertical"
-        data-reka-menu-content=""
-        data-reka-menubar-content=""
-        data-side="bottom"
-        data-slot="content"
-        data-state="open"
-        dir="ltr"
-        id="reka-menubar-content-v-4"
-        role="menu"
-        style="--reka-menubar-content-transform-origin: var(--reka-popper-transform-origin); --reka-menubar-content-available-width: var(--reka-popper-available-width); --reka-menubar-content-available-height: var(--reka-popper-available-height); --reka-menubar-trigger-width: var(--reka-popper-anchor-width); --reka-menubar-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-        tabindex="-1"
-      >
-        
-        
-        
-        
-        
-        
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                New
-              </span>
-              <!--v-if-->
+    <div data-reka-popper-content-wrapper>
+      <div aria-labelledby="reka-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-menubar-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-reka-menubar-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-menubar-content-v-4" role="menu" tabindex="-1">
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">New</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+N
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+N</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Open
-              </span>
-              <!--v-if-->
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Open</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+O
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+O</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Save
-              </span>
-              <!--v-if-->
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Save</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+S
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+S</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        
-        
-        
-        
-        
-        
       </div>
     </div>
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
-    <button
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="closed"
-      data-value="reka-v-2"
-      id="reka-v-2"
-      role="menuitem"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Edit
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-expanded="false" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="closed" data-value="reka-v-2" id="reka-v-2" role="menuitem" tabindex="-1" type="button">
+      <span class="truncate" data-slot="label">Edit</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <!---->
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;
 
 exports[`Menubar > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-controls="reka-menubar-content-v-4"
-      aria-disabled="false"
-      aria-expanded="true"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1 px-2 py-1 text-xs text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-highlighted=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="open"
-      data-value="reka-v-0"
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="0"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        File
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="0">
+    <button aria-controls="reka-menubar-content-v-4" aria-disabled="false" aria-expanded="true" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2 py-1 rounded-md text-default text-xs transition-colors" data-highlighted data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="open" data-value="reka-v-0" id="reka-v-0" role="menuitem" tabindex="0" type="button">
+      <span class="truncate" data-slot="label">File</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <div
-      data-reka-popper-content-wrapper=""
-      style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 32px); min-width: max-content; --reka-popper-transform-origin: 0% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 856.0124988555908px; --reka-popper-anchor-width: 33.95000076293945px; --reka-popper-anchor-height: 23.98750114440918px;"
-    >
-      <div
-        aria-labelledby="reka-v-0"
-        aria-orientation="vertical"
-        class="pointer-events-auto min-w-32 origin-(--reka-menubar-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-        data-align="start"
-        data-dismissable-layer=""
-        data-orientation="vertical"
-        data-reka-menu-content=""
-        data-reka-menubar-content=""
-        data-side="bottom"
-        data-slot="content"
-        data-state="open"
-        dir="ltr"
-        id="reka-menubar-content-v-4"
-        role="menu"
-        style="--reka-menubar-content-transform-origin: var(--reka-popper-transform-origin); --reka-menubar-content-available-width: var(--reka-popper-available-width); --reka-menubar-content-available-height: var(--reka-popper-available-height); --reka-menubar-trigger-width: var(--reka-popper-anchor-width); --reka-menubar-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-        tabindex="-1"
-      >
-        
-        
-        
-        
-        
-        
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                New
-              </span>
-              <!--v-if-->
+    <div data-reka-popper-content-wrapper>
+      <div aria-labelledby="reka-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-menubar-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-reka-menubar-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-menubar-content-v-4" role="menu" tabindex="-1">
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">New</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+N
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+N</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Open
-              </span>
-              <!--v-if-->
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Open</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+O
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+O</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1 p-1 text-xs"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Save
-              </span>
-              <!--v-if-->
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1 group items-center outline-none p-1 relative rounded-sm select-none text-default text-xs w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Save</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+S
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+S</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        
-        
-        
-        
-        
-        
       </div>
     </div>
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
-    <button
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1 px-2 py-1 text-xs text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="closed"
-      data-value="reka-v-2"
-      id="reka-v-2"
-      role="menuitem"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Edit
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-expanded="false" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2 py-1 rounded-md text-default text-xs transition-colors" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="closed" data-value="reka-v-2" id="reka-v-2" role="menuitem" tabindex="-1" type="button">
+      <span class="truncate" data-slot="label">Edit</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <!---->
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;
 
 exports[`Menubar > renders correctly with submenu menus 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-controls="reka-menubar-content-v-2"
-      aria-disabled="false"
-      aria-expanded="true"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated"
-      data-highlighted=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="open"
-      data-value="reka-v-0"
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="0"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Tools
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="0">
+    <button aria-controls="reka-menubar-content-v-2" aria-disabled="false" aria-expanded="true" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-highlighted data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="open" data-value="reka-v-0" id="reka-v-0" role="menuitem" tabindex="0" type="button">
+      <span class="truncate" data-slot="label">Tools</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <div
-      data-reka-popper-content-wrapper=""
-      style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 40px); min-width: max-content; --reka-popper-transform-origin: 0% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 848px; --reka-popper-anchor-width: 51.712501525878906px; --reka-popper-anchor-height: 32px;"
-    >
-      <div
-        aria-labelledby="reka-v-0"
-        aria-orientation="vertical"
-        class="pointer-events-auto min-w-32 origin-(--reka-menubar-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-        data-align="start"
-        data-dismissable-layer=""
-        data-orientation="vertical"
-        data-reka-menu-content=""
-        data-reka-menubar-content=""
-        data-side="bottom"
-        data-slot="content"
-        data-state="open"
-        dir="ltr"
-        id="reka-menubar-content-v-2"
-        role="menu"
-        style="--reka-menubar-content-transform-origin: var(--reka-popper-transform-origin); --reka-menubar-content-available-width: var(--reka-popper-available-width); --reka-menubar-content-available-height: var(--reka-popper-available-height); --reka-menubar-trigger-width: var(--reka-popper-anchor-width); --reka-menubar-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-        tabindex="-1"
-      >
-        
-        
-        
-        
-        
-        
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          
-          
-          
-          <div
-            aria-controls="reka-menu-sub-content-v-4"
-            aria-expanded="false"
-            aria-haspopup="menu"
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-reka-menubar-subtrigger=""
-            data-slot="item"
-            data-state="closed"
-            id="reka-menu-sub-trigger-v-3"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="truncate"
-              data-slot="itemLabel"
-            >
-              More Tools
+    <div data-reka-popper-content-wrapper>
+      <div aria-labelledby="reka-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-menubar-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-reka-menubar-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-menubar-content-v-2" role="menu" tabindex="-1">
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div aria-controls="reka-menu-sub-content-v-4" aria-expanded="false" aria-haspopup="menu" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-reka-menubar-subtrigger data-slot="item" data-state="closed" id="reka-menu-sub-trigger-v-3" role="menuitem" tabindex="-1">
+            <span class="truncate" data-slot="itemLabel">More Tools</span>
+            <span class="inline-flex items-center ms-auto" data-slot="itemTrailing">
+              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
             </span>
-            <span
-              class="ms-auto inline-flex items-center"
-              data-slot="itemTrailing"
-            >
-              <svg
-                aria-hidden="true"
-                class="shrink-0 size-5"
-                data-slot="itemTrailingIcon"
-                height="1em"
-                role="img"
-                viewBox="0 0 16 16"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              />
-            </span>
-            
-            
-            
           </div>
-          <!--teleport start-->
-          
-          
-          
-          <!---->
-          
-          
-          
-          <!--teleport end-->
-          
-          
-          
-          
-          
-          
-          
         </div>
-        
-        
-        
-        
-        
-        
       </div>
     </div>
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;
 
 exports[`Menubar > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="flex items-center gap-1 bg-default"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-    role="menubar"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    
-    
-    
-    
-    <button
-      aria-controls="reka-menubar-content-v-4"
-      aria-disabled="false"
-      aria-expanded="true"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated font-bold"
-      data-highlighted=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="open"
-      data-value="reka-v-0"
-      id="reka-v-0"
-      role="menuitem"
-      tabindex="0"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        File
-      </span>
-      
-      
-      <!--v-if-->
-      
+  <div class="bg-default flex gap-1 items-center" data-orientation="horizontal" data-slot="root" dir="ltr" role="menubar" tabindex="0">
+    <button aria-controls="reka-menubar-content-v-4" aria-disabled="false" aria-expanded="true" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 font-bold gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-highlighted data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="open" data-value="reka-v-0" id="reka-v-0" role="menuitem" tabindex="0" type="button">
+      <span class="truncate" data-slot="label">File</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <div
-      data-reka-popper-content-wrapper=""
-      style="position: fixed; left: 0px; top: 0px; transform: translate(8px, 40px); min-width: max-content; --reka-popper-transform-origin: 0% 0px; z-index: auto; --reka-popper-available-width: 398px; --reka-popper-available-height: 848px; --reka-popper-anchor-width: 42.8125px; --reka-popper-anchor-height: 32px;"
-    >
-      <div
-        aria-labelledby="reka-v-0"
-        aria-orientation="vertical"
-        class="pointer-events-auto min-w-32 origin-(--reka-menubar-content-transform-origin) divide-y divide-default overflow-hidden rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-        data-align="start"
-        data-dismissable-layer=""
-        data-orientation="vertical"
-        data-reka-menu-content=""
-        data-reka-menubar-content=""
-        data-side="bottom"
-        data-slot="content"
-        data-state="open"
-        dir="ltr"
-        id="reka-menubar-content-v-4"
-        role="menu"
-        style="--reka-menubar-content-transform-origin: var(--reka-popper-transform-origin); --reka-menubar-content-available-width: var(--reka-popper-available-width); --reka-menubar-content-available-height: var(--reka-popper-available-height); --reka-menubar-trigger-width: var(--reka-popper-anchor-width); --reka-menubar-trigger-height: var(--reka-popper-anchor-height); outline: none;"
-        tabindex="-1"
-      >
-        
-        
-        
-        
-        
-        
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                New
-              </span>
-              <!--v-if-->
+    <div data-reka-popper-content-wrapper>
+      <div aria-labelledby="reka-v-0" aria-orientation="vertical" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] divide-default divide-y focus:outline-none min-w-32 origin-(--reka-menubar-content-transform-origin) overflow-hidden pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="start" data-dismissable-layer data-orientation="vertical" data-reka-menu-content data-reka-menubar-content data-side="bottom" data-slot="content" data-state="open" dir="ltr" id="reka-menubar-content-v-4" role="menu" tabindex="-1">
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">New</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+N
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+N</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Open
-              </span>
-              <!--v-if-->
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Open</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+O
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+O</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        <div
-          class="isolate p-1"
-          data-slot="group"
-          role="group"
-        >
-          
-          
-          
-          
-          <div
-            class="group relative flex w-full cursor-pointer items-center rounded-sm text-default outline-none select-none before:absolute before:inset-px before:z-[-1] before:rounded-md data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 gap-1.5 p-1.5 text-sm"
-            data-reka-collection-item=""
-            data-slot="item"
-            role="menuitem"
-            tabindex="-1"
-          >
-            
-            
-            
-            <!--v-if-->
-            <span
-              class="flex min-w-0 flex-1 flex-col"
-            >
-              <span
-                class="truncate"
-                data-slot="itemLabel"
-              >
-                Save
-              </span>
-              <!--v-if-->
+        <div class="isolate p-1" data-slot="group" role="group">
+          <div class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" role="menuitem" tabindex="-1">
+            <span class="flex flex-1 flex-col min-w-0">
+              <span class="truncate" data-slot="itemLabel">Save</span>
             </span>
-            <span
-              class="ms-auto inline-flex items-center flex items-center gap-0.5"
-              data-slot="itemTrailing"
-            >
-              
-              <kbd
-                class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-                data-slot="base"
-              >
-                Ctrl+S
-              </kbd>
-              
+            <span class="flex gap-0.5 inline-flex items-center items-center ms-auto" data-slot="itemTrailing">
+              <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+S</kbd>
             </span>
-            
-            
-            
           </div>
-          
-          
-          
-          
         </div>
-        
-        
-        
-        
-        
-        
       </div>
     </div>
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
-    <button
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent aria-disabled:bg-transparent gap-1.5 px-2.5 py-1.5 text-sm text-default hover:bg-elevated focus-visible:outline-inverted active:bg-elevated font-bold"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="trigger"
-      data-state="closed"
-      data-value="reka-v-2"
-      id="reka-v-2"
-      role="menuitem"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <!--v-if-->
-      
-      
-      <span
-        class="truncate"
-        data-slot="label"
-      >
-        Edit
-      </span>
-      
-      
-      <!--v-if-->
-      
+    <button aria-disabled="false" aria-expanded="false" aria-haspopup="menu" class="active:bg-elevated aria-disabled:bg-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:bg-transparent disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 font-bold gap-1.5 hover:bg-elevated hover:cursor-pointer inline-flex items-center justify-center px-2.5 py-1.5 rounded-md text-default text-sm transition-colors" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="closed" data-value="reka-v-2" id="reka-v-2" role="menuitem" tabindex="-1" type="button">
+      <span class="truncate" data-slot="label">Edit</span>
     </button>
-    <!--teleport start-->
-    
-    
-    
-    <!---->
-    
-    
-    
-    <!--teleport end-->
-    
-    
-    
-    
-    
-    
   </div>
 </div>
 `;

--- a/packages/ui/src/components/Menubar/__snapshots__/Menubar.spec.ts.snap
+++ b/packages/ui/src/components/Menubar/__snapshots__/Menubar.spec.ts.snap
@@ -13,7 +13,9 @@ exports[`Menubar > renders correctly with checkbox menus 1`] = `
           <div aria-orientation="horizontal" class="-mx-1 bg-border h-px my-1" data-slot="separator" role="separator"></div>
           <div aria-checked="true" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="checked" role="menuitemcheckbox" tabindex="-1">
             <span class="truncate" data-slot="itemLabel">Show Grid</span>
-            <svg aria-hidden="true" class="inline-flex items-center ms-auto shrink-0 size-5" data-slot="itemTrailingIcon" data-state="checked" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+            <svg aria-hidden="true" class="iconify iconify--lucide inline-flex items-center ms-auto shrink-0 size-5" data-slot="itemTrailingIcon" data-state="checked" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+            </svg>
           </div>
           <div aria-checked="false" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-slot="item" data-state="unchecked" role="menuitemcheckbox" tabindex="-1">
             <span class="truncate" data-slot="itemLabel">Show Rulers</span>
@@ -272,7 +274,9 @@ exports[`Menubar > renders correctly with submenu menus 1`] = `
           <div aria-controls="reka-menu-sub-content-v-4" aria-expanded="false" aria-haspopup="menu" class="before:absolute before:inset-px before:rounded-md before:z-[-1] cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-75 data-highlighted:before:bg-elevated/50 flex gap-1.5 group items-center outline-none p-1.5 relative rounded-sm select-none text-default text-sm w-full" data-reka-collection-item data-reka-menubar-subtrigger data-slot="item" data-state="closed" id="reka-menu-sub-trigger-v-3" role="menuitem" tabindex="-1">
             <span class="truncate" data-slot="itemLabel">More Tools</span>
             <span class="inline-flex items-center ms-auto" data-slot="itemTrailing">
-              <svg aria-hidden="true" class="shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+              <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5" data-slot="itemTrailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path d="m9 18l6-6l-6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+              </svg>
             </span>
           </div>
         </div>

--- a/packages/ui/src/components/Popover/Popover.spec.ts
+++ b/packages/ui/src/components/Popover/Popover.spec.ts
@@ -23,6 +23,6 @@ describe("Popover", () => {
     });
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Popover/__snapshots__/Popover.spec.ts.snap
+++ b/packages/ui/src/components/Popover/__snapshots__/Popover.spec.ts.snap
@@ -1,208 +1,34 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Popover > renders correctly with arrow 1`] = `
-<div>
-  
-  
-  Trigger
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      aria-labelledby="reka-popover-trigger-v-0"
-      class="pointer-events-auto origin-(--reka-popover-content-transform-origin) rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      id="reka-popover-content-v-1"
-      role="dialog"
-      style="--reka-popover-content-transform-origin: var(--reka-popper-transform-origin); --reka-popover-content-available-width: var(--reka-popper-available-width); --reka-popover-content-available-height: var(--reka-popper-available-height); --reka-popover-trigger-width: var(--reka-popper-anchor-width); --reka-popover-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      Content
-      
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+<div>Trigger<div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-popover-trigger-v-0" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] focus:outline-none origin-(--reka-popover-content-transform-origin) pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="open" id="reka-popover-content-v-1" role="dialog" tabindex="-1">Content<span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;
 
 exports[`Popover > renders correctly with class 1`] = `
-<div>
-  
-  
-  Trigger
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      aria-labelledby="reka-popover-trigger-v-0"
-      class="pointer-events-auto origin-(--reka-popover-content-transform-origin) rounded-md bg-default ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] shadow-xl"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      id="reka-popover-content-v-1"
-      role="dialog"
-      style="--reka-popover-content-transform-origin: var(--reka-popper-transform-origin); --reka-popover-content-available-width: var(--reka-popper-available-width); --reka-popover-content-available-height: var(--reka-popper-available-height); --reka-popover-trigger-width: var(--reka-popper-anchor-width); --reka-popover-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      Content
-      
-      <!--v-if-->
-      
-      
-      
-      
-    </div>
+<div>Trigger<div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-popover-trigger-v-0" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] focus:outline-none origin-(--reka-popover-content-transform-origin) pointer-events-auto ring ring-default rounded-md shadow-xl" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="open" id="reka-popover-content-v-1" role="dialog" tabindex="-1">Content</div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;
 
 exports[`Popover > renders correctly with open 1`] = `
-<div>
-  
-  
-  Trigger
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      aria-labelledby="reka-popover-trigger-v-0"
-      class="pointer-events-auto origin-(--reka-popover-content-transform-origin) rounded-md bg-default shadow-lg ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      id="reka-popover-content-v-1"
-      role="dialog"
-      style="--reka-popover-content-transform-origin: var(--reka-popper-transform-origin); --reka-popover-content-available-width: var(--reka-popper-available-width); --reka-popover-content-available-height: var(--reka-popper-available-height); --reka-popover-trigger-width: var(--reka-popper-anchor-width); --reka-popover-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      Content
-      
-      <!--v-if-->
-      
-      
-      
-      
-    </div>
+<div>Trigger<div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-popover-trigger-v-0" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] focus:outline-none origin-(--reka-popover-content-transform-origin) pointer-events-auto ring ring-default rounded-md shadow-lg" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="open" id="reka-popover-content-v-1" role="dialog" tabindex="-1">Content</div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;
 
 exports[`Popover > renders correctly with ui 1`] = `
-<div>
-  
-  
-  Trigger
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      aria-labelledby="reka-popover-trigger-v-0"
-      class="pointer-events-auto origin-(--reka-popover-content-transform-origin) rounded-md bg-default ring ring-default focus:outline-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] shadow-xl"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="open"
-      id="reka-popover-content-v-1"
-      role="dialog"
-      style="--reka-popover-content-transform-origin: var(--reka-popper-transform-origin); --reka-popover-content-available-width: var(--reka-popper-available-width); --reka-popover-content-available-height: var(--reka-popper-available-height); --reka-popover-trigger-width: var(--reka-popper-anchor-width); --reka-popover-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-      tabindex="-1"
-    >
-      
-      
-      
-      
-      
-      Content
-      
-      <!--v-if-->
-      
-      
-      
-      
-    </div>
+<div>Trigger<div data-reka-popper-content-wrapper>
+    <div aria-labelledby="reka-popover-trigger-v-0" class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=open]:animate-[scale-in_100ms_ease-out] focus:outline-none origin-(--reka-popover-content-transform-origin) pointer-events-auto ring ring-default rounded-md shadow-xl" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="open" id="reka-popover-content-v-1" role="dialog" tabindex="-1">Content</div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
 </div>
 `;

--- a/packages/ui/src/components/Progress/Progress.spec.ts
+++ b/packages/ui/src/components/Progress/Progress.spec.ts
@@ -24,6 +24,6 @@ describe("Progress", () => {
     const screen = page.render(Progress, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Progress/__snapshots__/Progress.spec.ts.snap
+++ b/packages/ui/src/components/Progress/__snapshots__/Progress.spec.ts.snap
@@ -2,555 +2,160 @@
 
 exports[`Progress > renders correctly indeterminate 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with class 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2 my-4"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 my-4 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with color error 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-error"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-error data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with color help 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-help"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-help data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with color info 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-info"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-info data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with color neutral 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-inverted"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-inverted data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with color primary 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with color success 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-success"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-success data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with color warning 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-warning"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-warning data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with modelValue 0 1`] = `
 <div>
-  <div
-    aria-label="0%"
-    aria-valuemax="100"
-    aria-valuemin="0"
-    aria-valuenow="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="loading"
-    data-value="0"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="loading"
-      data-value="0"
-      style="transform: translateX(-100%);"
-    >
-      
-      
-    </div>
-    
+  <div aria-label="0%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="loading" data-value="0" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="loading" data-value="0"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with modelValue 50 1`] = `
 <div>
-  <div
-    aria-label="50%"
-    aria-valuemax="100"
-    aria-valuemin="0"
-    aria-valuenow="50"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="loading"
-    data-value="50"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="loading"
-      data-value="50"
-      style="transform: translateX(-50%);"
-    >
-      
-      
-    </div>
-    
+  <div aria-label="50%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="loading" data-value="50" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="loading" data-value="50"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with modelValue 100 1`] = `
 <div>
-  <div
-    aria-label="100%"
-    aria-valuemax="100"
-    aria-valuemin="0"
-    aria-valuenow="100"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="complete"
-    data-value="100"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="complete"
-      data-value="100"
-      style="transform: translateX(0%);"
-    >
-      
-      
-    </div>
-    
+  <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="complete" data-value="100" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with orientation horizontal 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with orientation vertical 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented h-full w-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel-vertical_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-full overflow-hidden relative rounded-full w-2" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel-vertical_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with size lg 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-3"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-3 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with size md 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-2"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with size sm 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-1"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-1 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with size xl 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-4"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-4 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with size xs 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full bg-accented w-full h-0.5"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-accented h-0.5 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;
 
 exports[`Progress > renders correctly with ui 1`] = `
 <div>
-  <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    class="relative overflow-hidden rounded-full w-full h-2 bg-default"
-    data-max="100"
-    data-slot="base"
-    data-state="indeterminate"
-    role="progressbar"
-    style="transform: translateZ(0px);"
-  >
-    
-    <div
-      class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-      data-max="100"
-      data-slot="indicator"
-      data-state="indeterminate"
-    >
-      
-      
-    </div>
-    
+  <div aria-valuemax="100" aria-valuemin="0" class="bg-default h-2 overflow-hidden relative rounded-full w-full" data-max="100" data-slot="base" data-state="indeterminate" role="progressbar">
+    <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="indeterminate"></div>
   </div>
 </div>
 `;

--- a/packages/ui/src/components/RadioGroup/RadioGroup.spec.ts
+++ b/packages/ui/src/components/RadioGroup/RadioGroup.spec.ts
@@ -30,7 +30,7 @@ describe("RadioGroup", () => {
     const screen = page.render(RadioGroup, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -45,7 +45,7 @@ describe("RadioGroup", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/RadioGroup/__snapshots__/RadioGroup.spec.ts.snap
+++ b/packages/ui/src/components/RadioGroup/__snapshots__/RadioGroup.spec.ts.snap
@@ -2,1450 +2,284 @@
 
 exports[`RadioGroup > renders correctly with class 1`] = `
 <div>
-  <div
-    aria-required="false"
-    class="flex flex-col items-start absolute"
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    role="radiogroup"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 1"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:1"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="1"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+  <div aria-required="false" class="absolute flex flex-col items-start" data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="0">
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 1" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:1" required="false" role="radio" tabindex="-1" type="button" value="1"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:1"
-        >
-          
-          Option 1
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:1">Option 1</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 2"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:2"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="2"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 2" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:2" required="false" role="radio" tabindex="-1" type="button" value="2"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:2"
-        >
-          
-          Option 2
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:2">Option 2</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 3"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:3"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="3"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 3" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:3" required="false" role="radio" tabindex="-1" type="button" value="3"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:3"
-        >
-          
-          Option 3
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:3">Option 3</label>
       </div>
     </div>
-    
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`RadioGroup > renders correctly with description 1`] = `
 <div>
-  <div
-    aria-required="false"
-    class="relative flex flex-col items-start"
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    role="radiogroup"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 1"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:1"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="1"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+  <div aria-required="false" class="flex flex-col items-start relative" data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="0">
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 1" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:1" required="false" role="radio" tabindex="-1" type="button" value="1"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:1"
-        >
-          
-          Option 1
-          
-        </label>
-        <p
-          class="text-muted"
-          data-slot="description"
-        >
-          Description 0
-        </p>
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:1">Option 1</label>
+        <p class="text-muted" data-slot="description">Description 0</p>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 2"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:2"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="2"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 2" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:2" required="false" role="radio" tabindex="-1" type="button" value="2"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:2"
-        >
-          
-          Option 2
-          
-        </label>
-        <p
-          class="text-muted"
-          data-slot="description"
-        >
-          Description 1
-        </p>
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:2">Option 2</label>
+        <p class="text-muted" data-slot="description">Description 1</p>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 3"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:3"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="3"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 3" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:3" required="false" role="radio" tabindex="-1" type="button" value="3"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:3"
-        >
-          
-          Option 3
-          
-        </label>
-        <p
-          class="text-muted"
-          data-slot="description"
-        >
-          Description 2
-        </p>
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:3">Option 3</label>
+        <p class="text-muted" data-slot="description">Description 2</p>
       </div>
     </div>
-    
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`RadioGroup > renders correctly with disabled 1`] = `
 <div>
-  <div
-    aria-required="false"
-    class="relative flex flex-col items-start"
-    data-disabled=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    role="radiogroup"
-    style="outline: none;"
-    tabindex="-1"
-  >
-    
-    
-    <div
-      class="flex items-start text-base opacity-75"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 1"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5 cursor-not-allowed"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          disabled=""
-          id="v-0:1"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="1"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+  <div aria-required="false" class="flex flex-col items-start relative" data-disabled data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="-1">
+    <div class="flex items-start opacity-75 text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 1" class="cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-disabled data-reka-collection-item data-slot="base" data-state="unchecked" disabled id="v-0:1" required="false" role="radio" tabindex="-1" type="button" value="1"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default cursor-not-allowed"
-          data-slot="label"
-          for="v-0:1"
-        >
-          
-          Option 1
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block cursor-not-allowed font-medium text-default" data-slot="label" for="v-0:1">Option 1</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base opacity-75"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 2"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5 cursor-not-allowed"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          disabled=""
-          id="v-0:2"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="2"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start opacity-75 text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 2" class="cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-disabled data-reka-collection-item data-slot="base" data-state="unchecked" disabled id="v-0:2" required="false" role="radio" tabindex="-1" type="button" value="2"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default cursor-not-allowed"
-          data-slot="label"
-          for="v-0:2"
-        >
-          
-          Option 2
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block cursor-not-allowed font-medium text-default" data-slot="label" for="v-0:2">Option 2</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base opacity-75"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 3"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5 cursor-not-allowed"
-          data-disabled=""
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          disabled=""
-          id="v-0:3"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="3"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start opacity-75 text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 3" class="cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-disabled data-reka-collection-item data-slot="base" data-state="unchecked" disabled id="v-0:3" required="false" role="radio" tabindex="-1" type="button" value="3"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default cursor-not-allowed"
-          data-slot="label"
-          for="v-0:3"
-        >
-          
-          Option 3
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block cursor-not-allowed font-medium text-default" data-slot="label" for="v-0:3">Option 3</label>
       </div>
     </div>
-    
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`RadioGroup > renders correctly with items 1`] = `
 <div>
-  <div
-    aria-required="false"
-    class="relative flex flex-col items-start"
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    role="radiogroup"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 1"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:1"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="1"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+  <div aria-required="false" class="flex flex-col items-start relative" data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="0">
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 1" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:1" required="false" role="radio" tabindex="-1" type="button" value="1"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:1"
-        >
-          
-          Option 1
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:1">Option 1</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 2"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:2"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="2"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 2" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:2" required="false" role="radio" tabindex="-1" type="button" value="2"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:2"
-        >
-          
-          Option 2
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:2">Option 2</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 3"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:3"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="3"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 3" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:3" required="false" role="radio" tabindex="-1" type="button" value="3"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:3"
-        >
-          
-          Option 3
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:3">Option 3</label>
       </div>
     </div>
-    
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`RadioGroup > renders correctly with size lg 1`] = `
 <div>
-  <div
-    aria-required="false"
-    class="relative flex flex-col items-start"
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    role="radiogroup"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="true"
-          aria-label="Option 1"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-active=""
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="checked"
-          id="v-0:1"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="1"
-        >
-          
-          
-          <span
-            class="flex size-full items-center justify-center after:rounded-full after:bg-default bg-primary after:size-2"
-            data-slot="indicator"
-            data-state="checked"
-          >
-            
-            
-          </span>
-          
-          
-          <!--v-if-->
+  <div aria-required="false" class="flex flex-col items-start relative" data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="0">
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="true" aria-label="Option 1" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-active data-reka-collection-item data-slot="base" data-state="checked" id="v-0:1" required="false" role="radio" tabindex="-1" type="button" value="1">
+          <span class="after:bg-default after:rounded-full after:size-2 bg-primary flex items-center justify-center size-full" data-slot="indicator" data-state="checked"></span>
         </button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:1"
-        >
-          
-          Option 1
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:1">Option 1</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 2"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:2"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="2"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 2" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:2" required="false" role="radio" tabindex="-1" type="button" value="2"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:2"
-        >
-          
-          Option 2
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:2">Option 2</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 3"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:3"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="3"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 3" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:3" required="false" role="radio" tabindex="-1" type="button" value="3"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:3"
-        >
-          
-          Option 3
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:3">Option 3</label>
       </div>
     </div>
-    
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`RadioGroup > renders correctly with size md 1`] = `
 <div>
-  <div
-    aria-required="false"
-    class="relative flex flex-col items-start"
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    role="radiogroup"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    <div
-      class="flex items-start text-sm"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-5"
-        data-slot="container"
-      >
-        <button
-          aria-checked="true"
-          aria-label="Option 1"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-4"
-          data-active=""
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="checked"
-          id="v-0:1"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="1"
-        >
-          
-          
-          <span
-            class="flex size-full items-center justify-center after:rounded-full after:bg-default bg-primary after:size-1.5"
-            data-slot="indicator"
-            data-state="checked"
-          >
-            
-            
-          </span>
-          
-          
-          <!--v-if-->
+  <div aria-required="false" class="flex flex-col items-start relative" data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="0">
+    <div class="flex items-start text-sm" data-slot="item">
+      <div class="flex h-5 items-center" data-slot="container">
+        <button aria-checked="true" aria-label="Option 1" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-4" data-active data-reka-collection-item data-slot="base" data-state="checked" id="v-0:1" required="false" role="radio" tabindex="-1" type="button" value="1">
+          <span class="after:bg-default after:rounded-full after:size-1.5 bg-primary flex items-center justify-center size-full" data-slot="indicator" data-state="checked"></span>
         </button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:1"
-        >
-          
-          Option 1
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:1">Option 1</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-sm"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-5"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 2"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-4"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:2"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="2"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-sm" data-slot="item">
+      <div class="flex h-5 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 2" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-4" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:2" required="false" role="radio" tabindex="-1" type="button" value="2"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:2"
-        >
-          
-          Option 2
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:2">Option 2</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-sm"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-5"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 3"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-4"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:3"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="3"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-sm" data-slot="item">
+      <div class="flex h-5 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 3" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-4" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:3" required="false" role="radio" tabindex="-1" type="button" value="3"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:3"
-        >
-          
-          Option 3
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:3">Option 3</label>
       </div>
     </div>
-    
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`RadioGroup > renders correctly with size sm 1`] = `
 <div>
-  <div
-    aria-required="false"
-    class="relative flex flex-col items-start"
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    role="radiogroup"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    <div
-      class="flex items-start text-xs"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-4"
-        data-slot="container"
-      >
-        <button
-          aria-checked="true"
-          aria-label="Option 1"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-3"
-          data-active=""
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="checked"
-          id="v-0:1"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="1"
-        >
-          
-          
-          <span
-            class="flex size-full items-center justify-center after:rounded-full after:bg-default bg-primary after:size-1"
-            data-slot="indicator"
-            data-state="checked"
-          >
-            
-            
-          </span>
-          
-          
-          <!--v-if-->
+  <div aria-required="false" class="flex flex-col items-start relative" data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="0">
+    <div class="flex items-start text-xs" data-slot="item">
+      <div class="flex h-4 items-center" data-slot="container">
+        <button aria-checked="true" aria-label="Option 1" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-3" data-active data-reka-collection-item data-slot="base" data-state="checked" id="v-0:1" required="false" role="radio" tabindex="-1" type="button" value="1">
+          <span class="after:bg-default after:rounded-full after:size-1 bg-primary flex items-center justify-center size-full" data-slot="indicator" data-state="checked"></span>
         </button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:1"
-        >
-          
-          Option 1
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:1">Option 1</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-xs"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-4"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 2"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-3"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:2"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="2"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-xs" data-slot="item">
+      <div class="flex h-4 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 2" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-3" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:2" required="false" role="radio" tabindex="-1" type="button" value="2"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:2"
-        >
-          
-          Option 2
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:2">Option 2</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-xs"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-4"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 3"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-3"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:3"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="3"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-xs" data-slot="item">
+      <div class="flex h-4 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 3" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-3" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:3" required="false" role="radio" tabindex="-1" type="button" value="3"></button>
       </div>
-      <div
-        class="ms-2 w-full"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:3"
-        >
-          
-          Option 3
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-2 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:3">Option 3</label>
       </div>
     </div>
-    
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`RadioGroup > renders correctly with ui 1`] = `
 <div>
-  <div
-    aria-required="false"
-    class="relative flex flex-col items-start"
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    role="radiogroup"
-    style="outline: none;"
-    tabindex="0"
-  >
-    
-    
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 1"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:1"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="1"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+  <div aria-required="false" class="flex flex-col items-start relative" data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="0">
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 1" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:1" required="false" role="radio" tabindex="-1" type="button" value="1"></button>
       </div>
-      <div
-        class="w-full ms-4"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:1"
-        >
-          
-          Option 1
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-4 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:1">Option 1</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 2"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:2"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="2"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 2" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:2" required="false" role="radio" tabindex="-1" type="button" value="2"></button>
       </div>
-      <div
-        class="w-full ms-4"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:2"
-        >
-          
-          Option 2
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-4 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:2">Option 2</label>
       </div>
     </div>
-    <div
-      class="flex items-start text-base"
-      data-slot="item"
-    >
-      <div
-        class="flex items-center h-6"
-        data-slot="container"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Option 3"
-          class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-          data-reka-collection-item=""
-          data-slot="base"
-          data-state="unchecked"
-          id="v-0:3"
-          required="false"
-          role="radio"
-          tabindex="-1"
-          type="button"
-          value="3"
-        >
-          
-          
-          <!---->
-          
-          
-          <!--v-if-->
-        </button>
+    <div class="flex items-start text-base" data-slot="item">
+      <div class="flex h-6 items-center" data-slot="container">
+        <button aria-checked="false" aria-label="Option 3" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:3" required="false" role="radio" tabindex="-1" type="button" value="3"></button>
       </div>
-      <div
-        class="w-full ms-4"
-        data-slot="wrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0:3"
-        >
-          
-          Option 3
-          
-        </label>
-        <!--v-if-->
+      <div class="ms-4 w-full" data-slot="wrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0:3">Option 3</label>
       </div>
     </div>
-    
-    
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`RadioGroup > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <!--v-if-->
-      <!--v-if-->
-    </div>
-    <div
-      class=""
-      data-slot="container"
-    >
-      
-      <div
-        aria-required="false"
-        class="relative flex flex-col items-start"
-        data-slot="root"
-        dir="ltr"
-        id="v-0"
-        role="radiogroup"
-        style="outline: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex items-start text-base"
-          data-slot="item"
-        >
-          <div
-            class="flex items-center h-6"
-            data-slot="container"
-          >
-            <button
-              aria-checked="false"
-              aria-label="Option 1"
-              class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-              data-reka-collection-item=""
-              data-slot="base"
-              data-state="unchecked"
-              id="v-0:Option 1"
-              required="false"
-              role="radio"
-              tabindex="-1"
-              type="button"
-              value="Option 1"
-            >
-              
-              
-              <!---->
-              
-              
-              <!--v-if-->
-            </button>
+  <div class data-slot="root">
+    <div class data-slot="wrapper"></div>
+    <div class data-slot="container">
+      <div aria-required="false" class="flex flex-col items-start relative" data-slot="root" dir="ltr" id="v-0" role="radiogroup" tabindex="0">
+        <div class="flex items-start text-base" data-slot="item">
+          <div class="flex h-6 items-center" data-slot="container">
+            <button aria-checked="false" aria-label="Option 1" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:Option 1" required="false" role="radio" tabindex="-1" type="button" value="Option 1"></button>
           </div>
-          <div
-            class="ms-2 w-full"
-            data-slot="wrapper"
-          >
-            <label
-              class="block font-medium text-default"
-              data-slot="label"
-              for="v-0:Option 1"
-            >
-              
-              Option 1
-              
-            </label>
-            <!--v-if-->
+          <div class="ms-2 w-full" data-slot="wrapper">
+            <label class="block font-medium text-default" data-slot="label" for="v-0:Option 1">Option 1</label>
           </div>
         </div>
-        <div
-          class="flex items-start text-base"
-          data-slot="item"
-        >
-          <div
-            class="flex items-center h-6"
-            data-slot="container"
-          >
-            <button
-              aria-checked="false"
-              aria-label="Option 2"
-              class="overflow-hidden rounded-full ring ring-accented ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary size-5"
-              data-reka-collection-item=""
-              data-slot="base"
-              data-state="unchecked"
-              id="v-0:Option 2"
-              required="false"
-              role="radio"
-              tabindex="-1"
-              type="button"
-              value="Option 2"
-            >
-              
-              
-              <!---->
-              
-              
-              <!--v-if-->
-            </button>
+        <div class="flex items-start text-base" data-slot="item">
+          <div class="flex h-6 items-center" data-slot="container">
+            <button aria-checked="false" aria-label="Option 2" class="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary overflow-hidden ring ring-accented ring-inset rounded-full size-5" data-reka-collection-item data-slot="base" data-state="unchecked" id="v-0:Option 2" required="false" role="radio" tabindex="-1" type="button" value="Option 2"></button>
           </div>
-          <div
-            class="ms-2 w-full"
-            data-slot="wrapper"
-          >
-            <label
-              class="block font-medium text-default"
-              data-slot="label"
-              for="v-0:Option 2"
-            >
-              
-              Option 2
-              
-            </label>
-            <!--v-if-->
+          <div class="ms-2 w-full" data-slot="wrapper">
+            <label class="block font-medium text-default" data-slot="label" for="v-0:Option 2">Option 2</label>
           </div>
         </div>
-        
-        
-        <!--v-if-->
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/Select/Select.spec.ts
+++ b/packages/ui/src/components/Select/Select.spec.ts
@@ -58,7 +58,7 @@ describe("Select", () => {
     const screen = page.render(Select, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -73,7 +73,7 @@ describe("Select", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/Select/__snapshots__/Select.spec.ts.snap
+++ b/packages/ui/src/components/Select/__snapshots__/Select.spec.ts.snap
@@ -5,7 +5,9 @@ exports[`Select > renders correctly with class 1`] = `
   <div class="absolute inline-flex items-center" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -16,7 +18,9 @@ exports[`Select > renders correctly with disabled 1`] = `
   <div class="inline-flex items-center relative" data-disabled dir="ltr">
     <button aria-controls aria-disabled="true" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 cursor-not-allowed disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between opacity-75 px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-disabled data-slot="base" data-state="closed" disabled id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -27,7 +31,9 @@ exports[`Select > renders correctly with disabled item 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -38,7 +44,9 @@ exports[`Select > renders correctly with grouped items 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -49,7 +57,9 @@ exports[`Select > renders correctly with icons 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="truncate" data-slot="value">Backlog</span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -60,7 +70,9 @@ exports[`Select > renders correctly with items 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -71,7 +83,9 @@ exports[`Select > renders correctly with loading 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="animate-spin shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="animate-spin iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="M21 12a9 9 0 1 1-6.219-8.56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -82,7 +96,9 @@ exports[`Select > renders correctly with modelValue 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="truncate" data-slot="value">Backlog</span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -93,7 +109,9 @@ exports[`Select > renders correctly with placeholder 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder">Select a status...</span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -104,7 +122,9 @@ exports[`Select > renders correctly with searchInput 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -115,7 +135,9 @@ exports[`Select > renders correctly with searchInput placeholder 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -126,7 +148,9 @@ exports[`Select > renders correctly with separator 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -137,7 +161,9 @@ exports[`Select > renders correctly with size lg 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -148,7 +174,9 @@ exports[`Select > renders correctly with size md 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1.5 inline-flex items-center justify-between px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-5 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-5 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -159,7 +187,9 @@ exports[`Select > renders correctly with size sm 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1 inline-flex items-center justify-between px-2 py-1 ring ring-accented ring-inset rounded-md text-start text-xs transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-4 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -170,7 +200,9 @@ exports[`Select > renders correctly with ui 1`] = `
   <div class="inline-flex items-center relative" dir="ltr">
     <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-full text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
       <span class="text-muted truncate" data-slot="placeholder"></span>
-      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+      <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+      </svg>
     </button>
   </div>
 </div>
@@ -190,7 +222,9 @@ exports[`Select > renders correctly within FormField 1`] = `
       <div class="inline-flex items-center relative" dir="ltr">
         <button aria-controls aria-describedby="v-0-hint v-0-description v-0-help" aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" tabindex="-1" type="button">
           <span class="text-muted truncate" data-slot="placeholder"></span>
-          <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="m6 9l6 6l6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
       </div>
       <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>

--- a/packages/ui/src/components/Select/__snapshots__/Select.spec.ts.snap
+++ b/packages/ui/src/components/Select/__snapshots__/Select.spec.ts.snap
@@ -2,1008 +2,198 @@
 
 exports[`Select > renders correctly with class 1`] = `
 <div>
-  
-  <div
-    class="inline-flex items-center absolute"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="absolute inline-flex items-center" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with disabled 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    data-disabled=""
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="true"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base cursor-not-allowed opacity-75 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-disabled=""
-      data-slot="base"
-      data-state="closed"
-      disabled=""
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" data-disabled dir="ltr">
+    <button aria-controls aria-disabled="true" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 cursor-not-allowed disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between opacity-75 px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-disabled data-slot="base" data-state="closed" disabled id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with disabled item 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with grouped items 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with icons 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate"
-        data-slot="value"
-      >
-        Backlog
-      </span>
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="truncate" data-slot="value">Backlog</span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with items 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with loading 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6 animate-spin"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="animate-spin shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with modelValue 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate"
-        data-slot="value"
-      >
-        Backlog
-      </span>
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="truncate" data-slot="value">Backlog</span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with placeholder 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      >
-        Select a status...
-      </span>
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder">Select a status...</span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with searchInput 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with searchInput placeholder 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with separator 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with size lg 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with size md 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1.5 px-2.5 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-5"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1.5 inline-flex items-center justify-between px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-5 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with size sm 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1 px-2 py-1 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-4"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1 inline-flex items-center justify-between px-2 py-1 ring ring-accented ring-inset rounded-md text-start text-xs transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-4 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly with ui 1`] = `
 <div>
-  
-  <div
-    class="relative inline-flex items-center"
-    dir="ltr"
-  >
-    
-    
-    <button
-      aria-controls=""
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Show popup"
-      class="inline-flex w-full items-center justify-between border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset rounded-full"
-      data-slot="base"
-      data-state="closed"
-      id="v-0"
-      open="true"
-      tabindex="-1"
-      type="button"
-    >
-      
-      <span
-        class="truncate text-muted"
-        data-slot="placeholder"
-      />
-      <svg
-        aria-hidden="true"
-        class="shrink-0 text-muted size-6"
-        data-slot="trailingIcon"
-        height="1em"
-        role="img"
-        viewBox="0 0 16 16"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      />
-      
+  <div class="inline-flex items-center relative" dir="ltr">
+    <button aria-controls aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-full text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" open="true" tabindex="-1" type="button">
+      <span class="text-muted truncate" data-slot="placeholder"></span>
+      <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
     </button>
-    <!--teleport start-->
-    
-    
-    <!---->
-    
-    
-    <!--teleport end-->
-    
-    
-    <!--v-if-->
   </div>
-  
 </div>
 `;
 
 exports[`Select > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      
-      <div
-        class="relative inline-flex items-center"
-        dir="ltr"
-      >
-        
-        
-        <button
-          aria-controls=""
-          aria-describedby="v-0-hint v-0-description v-0-help"
-          aria-disabled="false"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-label="Show popup"
-          class="inline-flex w-full items-center justify-between rounded-md border-0 text-start transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          data-state="closed"
-          id="v-0"
-          tabindex="-1"
-          type="button"
-        >
-          
-          <span
-            class="truncate text-muted"
-            data-slot="placeholder"
-          />
-          <svg
-            aria-hidden="true"
-            class="shrink-0 text-muted size-6"
-            data-slot="trailingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" dir="ltr">
+        <button aria-controls aria-describedby="v-0-hint v-0-description v-0-help" aria-disabled="false" aria-expanded="false" aria-haspopup="listbox" aria-label="Show popup" class="bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 inline-flex items-center justify-between px-3 py-2 ring ring-accented ring-inset rounded-md text-base text-start transition-colors w-full" data-slot="base" data-state="closed" id="v-0" tabindex="-1" type="button">
+          <span class="text-muted truncate" data-slot="placeholder"></span>
+          <svg aria-hidden="true" class="shrink-0 size-6 text-muted" data-slot="trailingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <!--teleport start-->
-        <!--teleport end-->
-        
-        
-        <!--v-if-->
       </div>
-      
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/Separator/Separator.spec.ts
+++ b/packages/ui/src/components/Separator/Separator.spec.ts
@@ -19,6 +19,6 @@ describe("Separator", () => {
     const screen = page.render(Separator, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Separator/__snapshots__/Separator.spec.ts.snap
+++ b/packages/ui/src/components/Separator/__snapshots__/Separator.spec.ts.snap
@@ -2,141 +2,60 @@
 
 exports[`Separator > renders correctly with class 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid border-default w-full border-t my-4"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div class="border-default border-solid border-t my-4 shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="separator"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with decorative 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid border-default w-full border-t"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="none"
-  >
-    
-    
-  </div>
+  <div class="border-default border-solid border-t shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="none"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with orientation horizontal 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid border-default w-full border-t"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div class="border-default border-solid border-t shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="separator"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with orientation vertical 1`] = `
 <div>
-  <div
-    aria-orientation="vertical"
-    class="shrink-0 border-solid border-default h-full border-s"
-    data-orientation="vertical"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div aria-orientation="vertical" class="border-default border-s border-solid h-full shrink-0" data-orientation="vertical" data-slot="base" role="separator"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid border-default w-full border-t-4"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div class="border-default border-solid border-t-4 shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="separator"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid border-default w-full border-t-3"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div class="border-default border-solid border-t-3 shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="separator"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid border-default w-full border-t-2"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div class="border-default border-solid border-t-2 shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="separator"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with size xl 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid border-default w-full border-t-5"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div class="border-default border-solid border-t-5 shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="separator"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with size xs 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid border-default w-full border-t"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div class="border-default border-solid border-t shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="separator"></div>
 </div>
 `;
 
 exports[`Separator > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="shrink-0 border-solid w-full border-t border-primary"
-    data-orientation="horizontal"
-    data-slot="base"
-    role="separator"
-  >
-    
-    
-  </div>
+  <div class="border-primary border-solid border-t shrink-0 w-full" data-orientation="horizontal" data-slot="base" role="separator"></div>
 </div>
 `;

--- a/packages/ui/src/components/Slider/Slider.spec.ts
+++ b/packages/ui/src/components/Slider/Slider.spec.ts
@@ -34,7 +34,7 @@ describe("Slider", () => {
     const screen = page.render(Wrapper, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -49,7 +49,7 @@ describe("Slider", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/Slider/__snapshots__/Slider.spec.ts.snap
+++ b/packages/ui/src/components/Slider/__snapshots__/Slider.spec.ts.snap
@@ -2,711 +2,132 @@
 
 exports[`Slider > renders correctly with class 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex touch-none items-center select-none w-64"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-64" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with disabled 1`] = `
 <div>
-  
-  <span
-    aria-disabled="true"
-    class="relative flex w-full touch-none items-center select-none cursor-not-allowed opacity-75"
-    data-disabled=""
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-      data-disabled=""
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-disabled=""
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="true" class="cursor-not-allowed flex items-center opacity-75 relative select-none touch-none w-full" data-disabled data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-disabled data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-disabled data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5 cursor-not-allowed"
-      data-disabled=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-disabled data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with id 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex w-full touch-none items-center select-none"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="volume"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="volume">
+    <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with min and max 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex w-full touch-none items-center select-none"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="50"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="50" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with size lg 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex w-full touch-none items-center select-none"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with size md 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex w-full touch-none items-center select-none"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-2"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-accented grow h-2 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-4"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-4" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with size sm 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex w-full touch-none items-center select-none"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-1.5"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-accented grow h-1.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-3"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-3" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with step 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex w-full touch-none items-center select-none"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with tooltip 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex w-full touch-none items-center select-none"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    
-    
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-      data-grace-area-trigger=""
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      data-state="closed"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <!--teleport start-->
-    <!--teleport end-->
-    
-    
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-grace-area-trigger data-orientation="horizontal" data-reka-collection-item data-slot="thumb" data-state="closed" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly with ui 1`] = `
 <div>
-  
-  <span
-    aria-disabled="false"
-    class="relative flex w-full touch-none items-center select-none"
-    data-orientation="horizontal"
-    data-slider-impl=""
-    data-slot="root"
-    dir="ltr"
-    id="v-0"
-    style="--reka-slider-thumb-transform: translateX(-50%);"
-  >
-    
-    
-    
-    <span
-      class="relative grow overflow-hidden rounded-full h-2.5 bg-red-500"
-      data-orientation="horizontal"
-      data-slot="track"
-    >
-      
-      <span
-        class="absolute h-full rounded-full bg-primary"
-        data-orientation="horizontal"
-        data-slot="range"
-        style="left: 0%; right: 100%;"
-      >
-        
-        
-      </span>
-      
+  <span aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+    <span class="bg-red-500 grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+      <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
     </span>
-    <span
-      aria-label="Thumb"
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-      data-orientation="horizontal"
-      data-reka-collection-item=""
-      data-slot="thumb"
-      role="slider"
-      style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
-    <!--v-if-->
-    
-    
+    <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
   </span>
-  
 </div>
 `;
 
 exports[`Slider > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <span
-        aria-describedby="v-0-hint v-0-description v-0-help"
-        aria-disabled="false"
-        class="relative flex w-full touch-none items-center select-none"
-        data-orientation="horizontal"
-        data-slider-impl=""
-        data-slot="root"
-        dir="ltr"
-        id="v-0"
-        style="--reka-slider-thumb-transform: translateX(-50%);"
-      >
-        
-        
-        
-        <span
-          class="relative grow overflow-hidden rounded-full bg-accented h-2.5"
-          data-orientation="horizontal"
-          data-slot="track"
-        >
-          
-          <span
-            class="absolute h-full rounded-full bg-primary"
-            data-orientation="horizontal"
-            data-slot="range"
-            style="left: 0%; right: 100%;"
-          >
-            
-            
-          </span>
-          
+    <div class="mt-1" data-slot="container">
+      <span aria-describedby="v-0-hint v-0-description v-0-help" aria-disabled="false" class="flex items-center relative select-none touch-none w-full" data-orientation="horizontal" data-slider-impl data-slot="root" dir="ltr" id="v-0">
+        <span class="bg-accented grow h-2.5 overflow-hidden relative rounded-full" data-orientation="horizontal" data-slot="track">
+          <span class="absolute bg-primary h-full rounded-full" data-orientation="horizontal" data-slot="range"></span>
         </span>
-        <span
-          aria-label="Thumb"
-          aria-orientation="horizontal"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="0"
-          class="block cursor-pointer rounded-full bg-default ring-2 focus-visible:outline-2 focus-visible:outline-offset-2 ring-primary focus-visible:outline-primary size-5"
-          data-orientation="horizontal"
-          data-reka-collection-item=""
-          data-slot="thumb"
-          role="slider"
-          style="transform: var(--reka-slider-thumb-transform); position: absolute; left: calc(0% + 0px);"
-          tabindex="0"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
-        
-        
+        <span aria-label="Thumb" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="bg-default block cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ring-2 ring-primary rounded-full size-5" data-orientation="horizontal" data-reka-collection-item data-slot="thumb" role="slider" tabindex="0"></span>
       </span>
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/Splitter/Splitter.spec.ts
+++ b/packages/ui/src/components/Splitter/Splitter.spec.ts
@@ -21,7 +21,7 @@ describe("Splitter", () => {
       const screen = page.render(Splitter, options);
       await nextTick();
 
-      expect(screen.container).toMatchSnapshot();
+      expect(screen.container.outerHTML).toMatchSnapshot();
     },
   );
 

--- a/packages/ui/src/components/Splitter/__snapshots__/Splitter.spec.ts.snap
+++ b/packages/ui/src/components/Splitter/__snapshots__/Splitter.spec.ts.snap
@@ -2,268 +2,32 @@
 
 exports[`Splitter > renders correctly with horizontal direction 1`] = `
 <div>
-  <div
-    data-orientation="horizontal"
-    data-panel-group=""
-    data-panel-group-id="reka-splitter-group-v-0"
-    data-slot="base"
-    style="display: flex; flex-direction: row; height: 100%; overflow: hidden; width: 100%;"
-  >
-    
-    
-    
-    <div
-      class=""
-      data-panel=""
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-id="reka-splitter-panel-v-1"
-      data-panel-size="50.0"
-      data-slot="panel"
-      id="reka-splitter-panel-v-1"
-      style="flex: 50 1 0px; overflow: hidden;"
-    >
-      
-      
-      Panel 1
-      
-      
-    </div>
-    <div
-      aria-controls="reka-splitter-panel-v-1"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="50"
-      class="border-2 border-default"
-      data-orientation="horizontal"
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-resize-handle-enabled="true"
-      data-panel-resize-handle-id="reka-splitter-resize-handle-v-2"
-      data-resize-handle=""
-      data-resize-handle-state="inactive"
-      data-slot="handle"
-      data-state="inactive"
-      id="reka-splitter-resize-handle-v-2"
-      role="separator"
-      style="touch-action: none; user-select: none;"
-      tabindex="0"
-    >
-      
-      
-    </div>
-    
-    
-    <div
-      class=""
-      data-panel=""
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-id="reka-splitter-panel-v-3"
-      data-panel-size="50.0"
-      data-slot="panel"
-      id="reka-splitter-panel-v-3"
-      style="flex: 50 1 0px; overflow: hidden;"
-    >
-      
-      
-      Panel 2
-      
-      
-    </div>
-    <!--v-if-->
-    
-    
-    
+  <div data-orientation="horizontal" data-panel-group data-panel-group-id="reka-splitter-group-v-0" data-slot="base">
+    <div class data-panel data-panel-group-id="reka-splitter-group-v-0" data-panel-id="reka-splitter-panel-v-1" data-panel-size="50.0" data-slot="panel" id="reka-splitter-panel-v-1">Panel 1</div>
+    <div aria-controls="reka-splitter-panel-v-1" aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="border-2 border-default" data-orientation="horizontal" data-panel-group-id="reka-splitter-group-v-0" data-panel-resize-handle-enabled="true" data-panel-resize-handle-id="reka-splitter-resize-handle-v-2" data-resize-handle data-resize-handle-state="inactive" data-slot="handle" data-state="inactive" id="reka-splitter-resize-handle-v-2" role="separator" tabindex="0"></div>
+    <div class data-panel data-panel-group-id="reka-splitter-group-v-0" data-panel-id="reka-splitter-panel-v-3" data-panel-size="50.0" data-slot="panel" id="reka-splitter-panel-v-3">Panel 2</div>
   </div>
 </div>
 `;
 
 exports[`Splitter > renders correctly with three panels 1`] = `
 <div>
-  <div
-    data-orientation="horizontal"
-    data-panel-group=""
-    data-panel-group-id="reka-splitter-group-v-0"
-    data-slot="base"
-    style="display: flex; flex-direction: row; height: 100%; overflow: hidden; width: 100%;"
-  >
-    
-    
-    
-    <div
-      class=""
-      data-panel=""
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-id="reka-splitter-panel-v-1"
-      data-panel-size="33.3"
-      data-slot="panel"
-      id="reka-splitter-panel-v-1"
-      style="flex: 33.3 1 0px; overflow: hidden;"
-    >
-      
-      
-      Panel 1
-      
-      
-    </div>
-    <div
-      aria-controls="reka-splitter-panel-v-1"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="33"
-      class="border-2 border-default"
-      data-orientation="horizontal"
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-resize-handle-enabled="true"
-      data-panel-resize-handle-id="reka-splitter-resize-handle-v-2"
-      data-resize-handle=""
-      data-resize-handle-state="inactive"
-      data-slot="handle"
-      data-state="inactive"
-      id="reka-splitter-resize-handle-v-2"
-      role="separator"
-      style="touch-action: none; user-select: none;"
-      tabindex="0"
-    >
-      
-      
-    </div>
-    
-    
-    <div
-      class=""
-      data-panel=""
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-id="reka-splitter-panel-v-3"
-      data-panel-size="33.3"
-      data-slot="panel"
-      id="reka-splitter-panel-v-3"
-      style="flex: 33.3 1 0px; overflow: hidden;"
-    >
-      
-      
-      Panel 2
-      
-      
-    </div>
-    <div
-      aria-controls="reka-splitter-panel-v-3"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="33"
-      class="border-2 border-default"
-      data-orientation="horizontal"
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-resize-handle-enabled="true"
-      data-panel-resize-handle-id="reka-splitter-resize-handle-v-4"
-      data-resize-handle=""
-      data-resize-handle-state="inactive"
-      data-slot="handle"
-      data-state="inactive"
-      id="reka-splitter-resize-handle-v-4"
-      role="separator"
-      style="touch-action: none; user-select: none;"
-      tabindex="0"
-    >
-      
-      
-    </div>
-    
-    
-    <div
-      class=""
-      data-panel=""
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-id="reka-splitter-panel-v-5"
-      data-panel-size="33.3"
-      data-slot="panel"
-      id="reka-splitter-panel-v-5"
-      style="flex: 33.3 1 0px; overflow: hidden;"
-    >
-      
-      
-      Panel 3
-      
-      
-    </div>
-    <!--v-if-->
-    
-    
-    
+  <div data-orientation="horizontal" data-panel-group data-panel-group-id="reka-splitter-group-v-0" data-slot="base">
+    <div class data-panel data-panel-group-id="reka-splitter-group-v-0" data-panel-id="reka-splitter-panel-v-1" data-panel-size="33.3" data-slot="panel" id="reka-splitter-panel-v-1">Panel 1</div>
+    <div aria-controls="reka-splitter-panel-v-1" aria-valuemax="100" aria-valuemin="0" aria-valuenow="33" class="border-2 border-default" data-orientation="horizontal" data-panel-group-id="reka-splitter-group-v-0" data-panel-resize-handle-enabled="true" data-panel-resize-handle-id="reka-splitter-resize-handle-v-2" data-resize-handle data-resize-handle-state="inactive" data-slot="handle" data-state="inactive" id="reka-splitter-resize-handle-v-2" role="separator" tabindex="0"></div>
+    <div class data-panel data-panel-group-id="reka-splitter-group-v-0" data-panel-id="reka-splitter-panel-v-3" data-panel-size="33.3" data-slot="panel" id="reka-splitter-panel-v-3">Panel 2</div>
+    <div aria-controls="reka-splitter-panel-v-3" aria-valuemax="100" aria-valuemin="0" aria-valuenow="33" class="border-2 border-default" data-orientation="horizontal" data-panel-group-id="reka-splitter-group-v-0" data-panel-resize-handle-enabled="true" data-panel-resize-handle-id="reka-splitter-resize-handle-v-4" data-resize-handle data-resize-handle-state="inactive" data-slot="handle" data-state="inactive" id="reka-splitter-resize-handle-v-4" role="separator" tabindex="0"></div>
+    <div class data-panel data-panel-group-id="reka-splitter-group-v-0" data-panel-id="reka-splitter-panel-v-5" data-panel-size="33.3" data-slot="panel" id="reka-splitter-panel-v-5">Panel 3</div>
   </div>
 </div>
 `;
 
 exports[`Splitter > renders correctly with vertical direction 1`] = `
 <div>
-  <div
-    data-orientation="vertical"
-    data-panel-group=""
-    data-panel-group-id="reka-splitter-group-v-0"
-    data-slot="base"
-    style="display: flex; flex-direction: column; height: 100%; overflow: hidden; width: 100%;"
-  >
-    
-    
-    
-    <div
-      class=""
-      data-panel=""
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-id="reka-splitter-panel-v-1"
-      data-panel-size="50.0"
-      data-slot="panel"
-      id="reka-splitter-panel-v-1"
-      style="flex: 50 1 0px; overflow: hidden;"
-    >
-      
-      
-      Panel 1
-      
-      
-    </div>
-    <div
-      aria-controls="reka-splitter-panel-v-1"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="50"
-      class="border-2 border-default"
-      data-orientation="vertical"
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-resize-handle-enabled="true"
-      data-panel-resize-handle-id="reka-splitter-resize-handle-v-2"
-      data-resize-handle=""
-      data-resize-handle-state="inactive"
-      data-slot="handle"
-      data-state="inactive"
-      id="reka-splitter-resize-handle-v-2"
-      role="separator"
-      style="touch-action: none; user-select: none;"
-      tabindex="0"
-    >
-      
-      
-    </div>
-    
-    
-    <div
-      class=""
-      data-panel=""
-      data-panel-group-id="reka-splitter-group-v-0"
-      data-panel-id="reka-splitter-panel-v-3"
-      data-panel-size="50.0"
-      data-slot="panel"
-      id="reka-splitter-panel-v-3"
-      style="flex: 50 1 0px; overflow: hidden;"
-    >
-      
-      
-      Panel 2
-      
-      
-    </div>
-    <!--v-if-->
-    
-    
-    
+  <div data-orientation="vertical" data-panel-group data-panel-group-id="reka-splitter-group-v-0" data-slot="base">
+    <div class data-panel data-panel-group-id="reka-splitter-group-v-0" data-panel-id="reka-splitter-panel-v-1" data-panel-size="50.0" data-slot="panel" id="reka-splitter-panel-v-1">Panel 1</div>
+    <div aria-controls="reka-splitter-panel-v-1" aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="border-2 border-default" data-orientation="vertical" data-panel-group-id="reka-splitter-group-v-0" data-panel-resize-handle-enabled="true" data-panel-resize-handle-id="reka-splitter-resize-handle-v-2" data-resize-handle data-resize-handle-state="inactive" data-slot="handle" data-state="inactive" id="reka-splitter-resize-handle-v-2" role="separator" tabindex="0"></div>
+    <div class data-panel data-panel-group-id="reka-splitter-group-v-0" data-panel-id="reka-splitter-panel-v-3" data-panel-size="50.0" data-slot="panel" id="reka-splitter-panel-v-3">Panel 2</div>
   </div>
 </div>
 `;

--- a/packages/ui/src/components/Switch/Switch.spec.ts
+++ b/packages/ui/src/components/Switch/Switch.spec.ts
@@ -22,7 +22,7 @@ describe("Switch", () => {
     const screen = page.render(Switch, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -37,7 +37,7 @@ describe("Switch", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/Switch/__snapshots__/Switch.spec.ts.snap
+++ b/packages/ui/src/components/Switch/__snapshots__/Switch.spec.ts.snap
@@ -2,97 +2,27 @@
 
 exports[`Switch > renders correctly with class 1`] = `
 <div>
-  <div
-    class="relative items-start inline-flex"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-6 w-11"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-5 data-[state=checked]:translate-x-5"
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="inline-flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-6 inline-flex items-center rounded-full shrink-0 transition-colors w-11" data-slot="base" data-state="unchecked" id="v-0" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-5 transition-transform" data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Switch > renders correctly with description 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-label="Label"
-        aria-required="false"
-        class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-6 w-11"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-5 data-[state=checked]:translate-x-5"
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-label="Label" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-6 inline-flex items-center rounded-full shrink-0 transition-colors w-11" data-slot="base" data-state="unchecked" id="v-0" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-5 transition-transform" data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <div
-      class="ms-2 w-full text-base"
-      data-slot="wrapper"
-    >
-      <label
-        class="block font-medium text-default"
-        data-slot="label"
-        for="v-0"
-      >
-        
-        Label
-        
-      </label>
-      <p
-        class="text-muted"
-        data-slot="description"
-      >
-        Description
-      </p>
+    <div class="ms-2 text-base w-full" data-slot="wrapper">
+      <label class="block font-medium text-default" data-slot="label" for="v-0">Label</label>
+      <p class="text-muted" data-slot="description">Description</p>
     </div>
   </div>
 </div>
@@ -100,134 +30,38 @@ exports[`Switch > renders correctly with description 1`] = `
 
 exports[`Switch > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="relative flex items-start opacity-75"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="inline-flex shrink-0 items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-6 w-11 cursor-not-allowed"
-        data-disabled=""
-        data-slot="base"
-        data-state="unchecked"
-        disabled=""
-        id="v-0"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-5 data-[state=checked]:translate-x-5"
-          data-disabled=""
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="flex items-start opacity-75 relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="border-2 border-transparent cursor-not-allowed data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-6 inline-flex items-center rounded-full shrink-0 transition-colors w-11" data-disabled data-slot="base" data-state="unchecked" disabled id="v-0" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-5 transition-transform" data-disabled data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Switch > renders correctly with id 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-6 w-11"
-        data-slot="base"
-        data-state="unchecked"
-        id="id"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-5 data-[state=checked]:translate-x-5"
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-6 inline-flex items-center rounded-full shrink-0 transition-colors w-11" data-slot="base" data-state="unchecked" id="id" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-5 transition-transform" data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Switch > renders correctly with label 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-label="Label"
-        aria-required="false"
-        class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-6 w-11"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-5 data-[state=checked]:translate-x-5"
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-label="Label" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-6 inline-flex items-center rounded-full shrink-0 transition-colors w-11" data-slot="base" data-state="unchecked" id="v-0" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-5 transition-transform" data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <div
-      class="ms-2 w-full text-base"
-      data-slot="wrapper"
-    >
-      <label
-        class="block font-medium text-default"
-        data-slot="label"
-        for="v-0"
-      >
-        
-        Label
-        
-      </label>
-      <!--v-if-->
+    <div class="ms-2 text-base w-full" data-slot="wrapper">
+      <label class="block font-medium text-default" data-slot="label" for="v-0">Label</label>
     </div>
   </div>
 </div>
@@ -235,229 +69,67 @@ exports[`Switch > renders correctly with label 1`] = `
 
 exports[`Switch > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-6 w-11"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-5 data-[state=checked]:translate-x-5"
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-6 inline-flex items-center rounded-full shrink-0 transition-colors w-11" data-slot="base" data-state="unchecked" id="v-0" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-5 transition-transform" data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Switch > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-5"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-5 w-9"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-4 data-[state=checked]:translate-x-4"
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-5 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-5 inline-flex items-center rounded-full shrink-0 transition-colors w-9" data-slot="base" data-state="unchecked" id="v-0" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-4 transition-transform" data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Switch > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-4"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-4 w-7"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-3 data-[state=checked]:translate-x-3"
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-4 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-4 inline-flex items-center rounded-full shrink-0 transition-colors w-7" data-slot="base" data-state="unchecked" id="v-0" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-3 transition-transform" data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Switch > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="relative flex items-start"
-    data-slot="root"
-  >
-    <div
-      class="flex items-center h-6"
-      data-slot="container"
-    >
-      <button
-        aria-checked="false"
-        aria-required="false"
-        class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-6 w-11"
-        data-slot="base"
-        data-state="unchecked"
-        id="v-0"
-        role="switch"
-        type="button"
-        value="on"
-      >
-        
-        <span
-          class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-5 data-[state=checked]:translate-x-5"
-          data-slot="thumb"
-          data-state="unchecked"
-        >
-          
-          
-        </span>
-        
-        <!--v-if-->
+  <div class="flex items-start relative" data-slot="root">
+    <div class="flex h-6 items-center" data-slot="container">
+      <button aria-checked="false" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-6 inline-flex items-center rounded-full shrink-0 transition-colors w-11" data-slot="base" data-state="unchecked" id="v-0" role="switch" type="button" value="on">
+        <span class="bg-default data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-5 transition-transform" data-slot="thumb" data-state="unchecked"></span>
       </button>
     </div>
-    <!--v-if-->
   </div>
 </div>
 `;
 
 exports[`Switch > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <!--v-if-->
-      <!--v-if-->
-    </div>
-    <div
-      class=""
-      data-slot="container"
-    >
-      
-      <div
-        class="relative flex items-start"
-        data-slot="root"
-      >
-        <div
-          class="flex items-center h-6"
-          data-slot="container"
-        >
-          <button
-            aria-checked="false"
-            aria-label="Label"
-            aria-required="false"
-            class="inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 data-[state=unchecked]:bg-accented focus-visible:outline-primary data-[state=checked]:bg-primary h-6 w-11"
-            data-slot="base"
-            data-state="unchecked"
-            id="v-0"
-            role="switch"
-            type="button"
-            value="on"
-          >
-            
-            <span
-              class="pointer-events-none rounded-full bg-default shadow-lg ring-0 transition-transform duration-200 data-[state=unchecked]:translate-x-0 size-5 data-[state=checked]:translate-x-5"
-              data-slot="thumb"
-              data-state="unchecked"
-            >
-              
-              
-            </span>
-            
-            <!--v-if-->
+  <div class data-slot="root">
+    <div class data-slot="wrapper"></div>
+    <div class data-slot="container">
+      <div class="flex items-start relative" data-slot="root">
+        <div class="flex h-6 items-center" data-slot="container">
+          <button aria-checked="false" aria-label="Label" aria-required="false" class="border-2 border-transparent cursor-pointer data-[state=checked]:bg-primary data-[state=unchecked]:bg-accented duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary h-6 inline-flex items-center rounded-full shrink-0 transition-colors w-11" data-slot="base" data-state="unchecked" id="v-0" role="switch" type="button" value="on">
+            <span class="bg-default data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 duration-200 pointer-events-none ring-0 rounded-full shadow-lg size-5 transition-transform" data-slot="thumb" data-state="unchecked"></span>
           </button>
         </div>
-        <div
-          class="ms-2 w-full text-base"
-          data-slot="wrapper"
-        >
-          <label
-            class="block font-medium text-default"
-            data-slot="label"
-            for="v-0"
-          >
-            
-            Label
-            
-          </label>
-          <!--v-if-->
+        <div class="ms-2 text-base w-full" data-slot="wrapper">
+          <label class="block font-medium text-default" data-slot="label" for="v-0">Label</label>
         </div>
       </div>
-      
-      <!--v-if-->
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/Tabs/Tabs.spec.ts
+++ b/packages/ui/src/components/Tabs/Tabs.spec.ts
@@ -33,7 +33,7 @@ describe("Tabs", () => {
     const screen = page.render(Tabs, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/Tabs/__snapshots__/Tabs.spec.ts.snap
+++ b/packages/ui/src/components/Tabs/__snapshots__/Tabs.spec.ts.snap
@@ -2,2427 +2,309 @@
 
 exports[`Tabs > renders correctly with class 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col w-96"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2 w-96" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with content slot 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content slot
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content slot</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with custom slot 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with default slot 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Default slot
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Default slot</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Default slot
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Default slot</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Default slot
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Default slot</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with items 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with leading slot 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        Leading slot
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">Leading slot<span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        Leading slot
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">Leading slot<span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        Leading slot
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">Leading slot<span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with orientation horizontal 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with orientation vertical 1`] = `
 <div>
-  <div
-    class="flex gap-2"
-    data-orientation="vertical"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="vertical"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 flex-col"
-      data-orientation="vertical"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted w-full px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="vertical"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex gap-2" data-orientation="vertical" data-slot="root" dir="ltr">
+    <div aria-orientation="vertical" class="bg-accented flex-col inline-flex items-center p-1 relative rounded-lg" data-orientation="vertical" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm w-full" data-active data-orientation="vertical" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted w-full px-2.5 py-1.5 text-sm"
-        data-orientation="vertical"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm w-full" data-orientation="vertical" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted w-full px-2.5 py-1.5 text-sm"
-        data-orientation="vertical"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm w-full" data-orientation="vertical" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="vertical"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="vertical"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="vertical"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="vertical" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="vertical" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="vertical" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-3 py-2 text-base"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-3 py-2 relative rounded-md shrink-0 text-base text-muted" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-3 py-2 text-base"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-3 py-2 relative rounded-md shrink-0 text-base text-muted" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-3 py-2 text-base"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-3 py-2 relative rounded-md shrink-0 text-base text-muted" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2 py-1 text-xs"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2 py-1 relative rounded-md shrink-0 text-muted text-xs" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2 py-1 text-xs"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2 py-1 relative rounded-md shrink-0 text-muted text-xs" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2 py-1 text-xs"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2 py-1 relative rounded-md shrink-0 text-muted text-xs" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with trailing slot 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        Trailing slot
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>Trailing slot
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        Trailing slot
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>Trailing slot
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        Trailing slot
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>Trailing slot
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="focus-visible:outline-none w-full ring ring-default"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="focus-visible:outline-none w-full ring ring-default"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="focus-visible:outline-none w-full ring ring-default"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <!--v-if-->
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none ring ring-default w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none ring ring-default w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0"></div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none ring ring-default w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0"></div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly with unmountOnHide false 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-controls="reka-tabs-v-0-content-0"
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-controls="reka-tabs-v-0-content-0" aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-1"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-1" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-controls="reka-tabs-v-0-content-2"
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-controls="reka-tabs-v-0-content-2" aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-0"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="active"
-      id="reka-tabs-v-0-content-0"
-      role="tabpanel"
-      style="animation-duration: 0s;"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab1
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-1"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab2
-      
-      
-    </div>
-    <div
-      aria-labelledby="reka-tabs-v-0-trigger-2"
-      class="w-full focus-visible:outline-none"
-      data-orientation="horizontal"
-      data-slot="content"
-      data-state="inactive"
-      hidden=""
-      id="reka-tabs-v-0-content-2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      
-      
-      Content for Tab3
-      
-      
-    </div>
-    
-    
+    <div aria-labelledby="reka-tabs-v-0-trigger-0" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="active" id="reka-tabs-v-0-content-0" role="tabpanel" tabindex="0">Content for Tab1</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-1" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-1" role="tabpanel" tabindex="0">Content for Tab2</div>
+    <div aria-labelledby="reka-tabs-v-0-trigger-2" class="focus-visible:outline-none w-full" data-orientation="horizontal" data-slot="content" data-state="inactive" hidden id="reka-tabs-v-0-content-2" role="tabpanel" tabindex="0">Content for Tab3</div>
   </div>
 </div>
 `;
 
 exports[`Tabs > renders correctly without content 1`] = `
 <div>
-  <div
-    class="flex gap-2 flex-col"
-    data-orientation="horizontal"
-    data-slot="root"
-    dir="ltr"
-  >
-    
-    <div
-      aria-orientation="horizontal"
-      class="relative inline-flex items-center rounded-lg bg-accented p-1 overflow-x-auto"
-      data-orientation="horizontal"
-      data-slot="list"
-      dir="ltr"
-      role="tablist"
-      style="outline: none;"
-      tabindex="0"
-    >
-      
-      <!--v-if-->
-      
-      
-      
-      <button
-        aria-selected="true"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-active=""
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="active"
-        id="reka-tabs-v-0-trigger-0"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab1
-          
-        </span>
-        
-        
-        
+  <div class="flex flex-col gap-2" data-orientation="horizontal" data-slot="root" dir="ltr">
+    <div aria-orientation="horizontal" class="bg-accented inline-flex items-center overflow-x-auto p-1 relative rounded-lg" data-orientation="horizontal" data-slot="list" dir="ltr" role="tablist" tabindex="0">
+      <button aria-selected="true" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-active data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="active" id="reka-tabs-v-0-trigger-0" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab1</span>
       </button>
-      <button
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-1"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab2
-          
-        </span>
-        
-        
-        
+      <button aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-1" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab2</span>
       </button>
-      <button
-        aria-selected="false"
-        class="relative inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md font-medium text-muted focus-visible:outline-2 focus-visible:outline-inverted disabled:cursor-not-allowed disabled:opacity-75 data-[state=active]:text-inverted px-2.5 py-1.5 text-sm"
-        data-orientation="horizontal"
-        data-reka-collection-item=""
-        data-slot="trigger"
-        data-state="inactive"
-        id="reka-tabs-v-0-trigger-2"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        
-        
-        
-        <span
-          class="truncate"
-          data-slot="label"
-        >
-          
-          Tab3
-          
-        </span>
-        
-        
-        
+      <button aria-selected="false" class="cursor-pointer data-[state=active]:text-inverted disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted font-medium gap-1.5 inline-flex items-center px-2.5 py-1.5 relative rounded-md shrink-0 text-muted text-sm" data-orientation="horizontal" data-reka-collection-item data-slot="trigger" data-state="inactive" id="reka-tabs-v-0-trigger-2" role="tab" tabindex="-1" type="button">
+        <span class="truncate" data-slot="label">Tab3</span>
       </button>
-      
-      
-      
-      
     </div>
-    <!--v-if-->
-    
   </div>
 </div>
 `;

--- a/packages/ui/src/components/Textarea/Textarea.spec.ts
+++ b/packages/ui/src/components/Textarea/Textarea.spec.ts
@@ -22,7 +22,7 @@ describe("Textarea", () => {
     const screen = page.render(Textarea, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   test("renders correctly within FormField", async () => {
@@ -37,7 +37,7 @@ describe("Textarea", () => {
     const screen = page.render(Wrapper);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 
   describe("emits", () => {

--- a/packages/ui/src/components/Textarea/__snapshots__/Textarea.spec.ts.snap
+++ b/packages/ui/src/components/Textarea/__snapshots__/Textarea.spec.ts.snap
@@ -2,215 +2,91 @@
 
 exports[`Textarea > renders correctly with autoresize 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base resize-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      rows="3"
-      style=""
-    />
+  <div class="inline-flex items-center relative" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 resize-none ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" rows="3"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly with class 1`] = `
 <div>
-  <div
-    class="inline-flex items-center absolute"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      rows="3"
-    />
+  <div class="absolute inline-flex items-center" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" rows="3"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly with disabled 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      disabled=""
-      id="v-0"
-      rows="3"
-    />
+  <div class="inline-flex items-center relative" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" disabled id="v-0" rows="3"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly with id 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="id"
-      rows="3"
-    />
+  <div class="inline-flex items-center relative" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="id" rows="3"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly with rows 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      rows="5"
-    />
+  <div class="inline-flex items-center relative" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" rows="5"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly with size lg 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      rows="3"
-    />
+  <div class="inline-flex items-center relative" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" rows="3"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly with size md 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1.5 px-2.5 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      rows="3"
-    />
+  <div class="inline-flex items-center relative" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1.5 px-2.5 py-1.5 ring ring-accented ring-inset rounded-md text-sm transition-colors w-full" data-slot="base" id="v-0" rows="3"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly with size sm 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-1 px-2 py-1 text-xs focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      data-slot="base"
-      id="v-0"
-      rows="3"
-    />
+  <div class="inline-flex items-center relative" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-1 px-2 py-1 ring ring-accented ring-inset rounded-md text-xs transition-colors w-full" data-slot="base" id="v-0" rows="3"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly with ui 1`] = `
 <div>
-  <div
-    class="relative inline-flex items-center"
-    data-slot="root"
-  >
-    <textarea
-      class="w-full appearance-none border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset rounded-full"
-      data-slot="base"
-      id="v-0"
-      rows="3"
-    />
+  <div class="inline-flex items-center relative" data-slot="root">
+    <textarea class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-full text-base transition-colors w-full" data-slot="base" id="v-0" rows="3"></textarea>
   </div>
 </div>
 `;
 
 exports[`Textarea > renders correctly within FormField 1`] = `
 <div>
-  <div
-    class=""
-    data-slot="root"
-  >
-    <div
-      class=""
-      data-slot="wrapper"
-    >
-      <div
-        class="flex items-center justify-between gap-1"
-        data-slot="labelWrapper"
-      >
-        <label
-          class="block font-medium text-default"
-          data-slot="label"
-          for="v-0"
-          id="v-0-label"
-        >
-          
-          Label
-          
-        </label>
-        <span
-          class="text-muted"
-          data-slot="hint"
-          id="v-0-hint"
-        >
-          Hint
-        </span>
+  <div class data-slot="root">
+    <div class data-slot="wrapper">
+      <div class="flex gap-1 items-center justify-between" data-slot="labelWrapper">
+        <label class="block font-medium text-default" data-slot="label" for="v-0" id="v-0-label">Label</label>
+        <span class="text-muted" data-slot="hint" id="v-0-hint">Hint</span>
       </div>
-      <p
-        class="text-muted"
-        data-slot="description"
-        id="v-0-description"
-      >
-        Description
-      </p>
+      <p class="text-muted" data-slot="description" id="v-0-description">Description</p>
     </div>
-    <div
-      class="mt-1"
-      data-slot="container"
-    >
-      
-      <div
-        class="relative inline-flex items-center"
-        data-slot="root"
-      >
-        <textarea
-          aria-describedby="v-0-hint v-0-description v-0-help"
-          class="w-full appearance-none rounded-md border-0 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 bg-elevated ring ring-accented ring-inset gap-2 px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-          data-slot="base"
-          id="v-0"
-          rows="3"
-        />
+    <div class="mt-1" data-slot="container">
+      <div class="inline-flex items-center relative" data-slot="root">
+        <textarea aria-describedby="v-0-hint v-0-description v-0-help" class="appearance-none bg-elevated border-0 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2 px-3 py-2 ring ring-accented ring-inset rounded-md text-base transition-colors w-full" data-slot="base" id="v-0" rows="3"></textarea>
       </div>
-      
-      <p
-        class="mt-1 text-muted"
-        data-slot="help"
-        id="v-0-help"
-      >
-        Help
-      </p>
+      <p class="mt-1 text-muted" data-slot="help" id="v-0-help">Help</p>
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/Toast/Toast.spec.ts
+++ b/packages/ui/src/components/Toast/Toast.spec.ts
@@ -45,7 +45,7 @@ describe("Toast", () => {
       const screen = page.render(ToastWrapper, options);
       await nextTick();
 
-      expect(screen.container).toMatchSnapshot();
+      expect(screen.container.outerHTML).toMatchSnapshot();
     },
   );
 });

--- a/packages/ui/src/components/Toast/__snapshots__/Toast.spec.ts.snap
+++ b/packages/ui/src/components/Toast/__snapshots__/Toast.spec.ts.snap
@@ -15,7 +15,9 @@ exports[`Toast > renders correctly with actions 1`] = `
           </div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -43,7 +45,9 @@ exports[`Toast > renders correctly with actions and description 1`] = `
           </div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -66,7 +70,9 @@ exports[`Toast > renders correctly with actions slot 1`] = `
           <div class="flex gap-1.5 items-start mt-2.5 shrink-0" data-slot="actions">Actions slot</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -88,7 +94,9 @@ exports[`Toast > renders correctly with class 1`] = `
           <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -128,7 +136,9 @@ exports[`Toast > renders correctly with color error 1`] = `
           <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-error data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -150,7 +160,9 @@ exports[`Toast > renders correctly with color neutral 1`] = `
           <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-inverted data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -172,7 +184,9 @@ exports[`Toast > renders correctly with color success 1`] = `
           <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-success data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -195,7 +209,9 @@ exports[`Toast > renders correctly with description 1`] = `
           <div class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description">This is a toast</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -218,7 +234,9 @@ exports[`Toast > renders correctly with description slot 1`] = `
           <div class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description">Description slot</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -240,7 +258,9 @@ exports[`Toast > renders correctly with title 1`] = `
           <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -263,7 +283,9 @@ exports[`Toast > renders correctly with title and description 1`] = `
           <div class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description">This is a toast</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -285,7 +307,9 @@ exports[`Toast > renders correctly with title slot 1`] = `
           <div class="font-medium text-sm" data-slot="title">Title slot</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
@@ -307,7 +331,9 @@ exports[`Toast > renders correctly with ui 1`] = `
           <div class="font-bold text-sm" data-slot="title">Toast</div>
         </div>
         <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
-          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
+          <svg aria-hidden="true" class="iconify iconify--lucide shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <path d="M18 6L6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+          </svg>
         </button>
         <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
           <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>

--- a/packages/ui/src/components/Toast/__snapshots__/Toast.spec.ts.snap
+++ b/packages/ui/src/components/Toast/__snapshots__/Toast.spec.ts.snap
@@ -2,2114 +2,319 @@
 
 exports[`Toast > renders correctly with actions 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <div
-            class="mt-2.5 flex shrink-0 items-start gap-1.5"
-            data-slot="actions"
-          >
-            
-            
-            <button
-              aria-disabled="false"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 px-2 py-1 text-xs bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-              data-reka-toast-announce-alt="Retry"
-              data-reka-toast-announce-exclude=""
-              data-slot="base"
-              type="button"
-            >
-              
-              <!--v-if-->
-              
-              
-              <span
-                class="truncate"
-                data-slot="label"
-              >
-                Retry
-              </span>
-              
-              
-              <!--v-if-->
-              
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
+          <div class="flex gap-1.5 items-start mt-2.5 shrink-0" data-slot="actions">
+            <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2 py-1 rounded-md text-inverted text-xs transition-colors" data-reka-toast-announce-alt="Retry" data-reka-toast-announce-exclude data-slot="base" type="button">
+              <span class="truncate" data-slot="label">Retry</span>
             </button>
-            
-            
           </div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with actions and description 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <div
-            class="text-sm whitespace-pre-line text-muted mt-1"
-            data-slot="description"
-          >
-            
-            
-            Something went wrong.
-            
-            
-          </div>
-          <div
-            class="mt-2.5 flex shrink-0 items-start gap-1.5"
-            data-slot="actions"
-          >
-            
-            
-            <button
-              aria-disabled="false"
-              class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1 px-2 py-1 text-xs bg-primary text-inverted hover:bg-primary/75 focus-visible:outline-primary active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary"
-              data-reka-toast-announce-alt="Retry"
-              data-reka-toast-announce-exclude=""
-              data-slot="base"
-              type="button"
-            >
-              
-              <!--v-if-->
-              
-              
-              <span
-                class="truncate"
-                data-slot="label"
-              >
-                Retry
-              </span>
-              
-              
-              <!--v-if-->
-              
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
+          <div class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description">Something went wrong.</div>
+          <div class="flex gap-1.5 items-start mt-2.5 shrink-0" data-slot="actions">
+            <button aria-disabled="false" class="active:bg-primary/75 aria-disabled:bg-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-75 bg-primary disabled:bg-primary disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary gap-1 hover:bg-primary/75 hover:cursor-pointer inline-flex items-center justify-center px-2 py-1 rounded-md text-inverted text-xs transition-colors" data-reka-toast-announce-alt="Retry" data-reka-toast-announce-exclude data-slot="base" type="button">
+              <span class="truncate" data-slot="label">Retry</span>
             </button>
-            
-            
           </div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with actions slot 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <div
-            class="mt-2.5 flex shrink-0 items-start gap-1.5"
-            data-slot="actions"
-          >
-            
-            
-            Actions slot
-            
-            
-          </div>
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
+          <div class="flex gap-1.5 items-start mt-2.5 shrink-0" data-slot="actions">Actions slot</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with class 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset w-96"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg w-96" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with close slot 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
+        </div>Close slot<div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        Close slot
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
-        </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with color error 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-error focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-error focus-visible:ring-inset focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-error"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-error data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with color neutral 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-inverted focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-inverted focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-inverted"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-inverted data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with color success 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-success focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-success focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-success"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-success data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with description 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <div
-            class="text-sm whitespace-pre-line text-muted mt-1"
-            data-slot="description"
-          >
-            
-            
-            This is a toast
-            
-            
-          </div>
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
+          <div class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description">This is a toast</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with description slot 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <div
-            class="text-sm whitespace-pre-line text-muted mt-1"
-            data-slot="description"
-          >
-            
-            
-            
-            Description slot
-            
-            
-            
-          </div>
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
+          <div class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description">Description slot</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with title 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with title and description 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <div
-            class="text-sm whitespace-pre-line text-muted mt-1"
-            data-slot="description"
-          >
-            
-            
-            This is a toast
-            
-            
-          </div>
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Toast</div>
+          <div class="mt-1 text-muted text-sm whitespace-pre-line" data-slot="description">This is a toast</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with title slot 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-medium"
-            data-slot="title"
-          >
-            
-            
-            
-            Title slot
-            
-            
-            
-          </div>
-          <!--v-if-->
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-medium text-sm" data-slot="title">Title slot</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;
 
 exports[`Toast > renders correctly with ui 1`] = `
 <div>
-  
-  
-  
-  <!--v-if-->
-  <!--teleport start-->
-  <!--teleport end-->
-  
-  
-  
-  
-  <!--teleport start-->
-  
-  
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    tabindex="-1"
-  >
-    
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    <ol
-      class="right-0 bottom-0 z-100 flex max-w-[100vw] flex-col-reverse gap-4 p-4 outline-none static w-auto"
-      data-slot="viewport"
-      tabindex="-1"
-    >
-      
-      
-      
-      <li
-        aria-atomic="true"
-        aria-live="off"
-        class="group relative flex items-start gap-2.5 overflow-hidden rounded-lg bg-default p-4 shadow-lg ring ring-default focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-        data-reka-collection-item=""
-        data-slot="root"
-        data-state="open"
-        data-swipe-direction="right"
-        role="alert"
-        style="user-select: none; touch-action: none;"
-        tabindex="0"
-      >
-        
-        
-        <div
-          class="flex w-0 flex-1 flex-col"
-          data-slot="wrapper"
-        >
-          <div
-            class="text-sm font-bold"
-            data-slot="title"
-          >
-            
-            
-            Toast
-            
-            
-          </div>
-          <!--v-if-->
-          <!--v-if-->
+  <div aria-label="Notifications (F8)" role="region" tabindex="-1">
+    <span aria-hidden="true" tabindex="0"></span>
+    <ol class="bottom-0 flex flex-col-reverse gap-4 max-w-[100vw] outline-none p-4 right-0 static w-auto z-100" data-slot="viewport" tabindex="-1">
+      <li aria-atomic="true" aria-live="off" class="bg-default flex focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus:outline-none gap-2.5 group items-start overflow-hidden p-4 relative ring ring-default rounded-lg shadow-lg" data-reka-collection-item data-slot="root" data-state="open" data-swipe-direction="right" role="alert" tabindex="0">
+        <div class="flex flex-1 flex-col w-0" data-slot="wrapper">
+          <div class="font-bold text-sm" data-slot="title">Toast</div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Close"
-          class="inline-flex items-center justify-center rounded-md transition-colors hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:cursor-not-allowed aria-disabled:opacity-75 gap-1.5 text-sm text-muted hover:text-default focus-visible:outline-inverted active:text-default p-0"
-          data-reka-toast-announce-exclude=""
-          data-slot="close"
-          type="button"
-        >
-          
-          <svg
-            aria-hidden="true"
-            class="shrink-0 size-4"
-            data-slot="leadingIcon"
-            height="1em"
-            role="img"
-            viewBox="0 0 16 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          />
-          
-          
-          <!--v-if-->
-          
-          
-          <!--v-if-->
-          
+        <button aria-disabled="false" aria-label="Close" class="active:text-default aria-disabled:cursor-not-allowed aria-disabled:opacity-75 disabled:cursor-not-allowed disabled:opacity-75 focus-visible:outline-2 focus-visible:outline-inverted focus-visible:outline-offset-2 gap-1.5 hover:cursor-pointer hover:text-default inline-flex items-center justify-center p-0 rounded-md text-muted text-sm transition-colors" data-reka-toast-announce-exclude data-slot="close" type="button">
+          <svg aria-hidden="true" class="shrink-0 size-4" data-slot="leadingIcon" height="1em" role="img" viewBox="0 0 16 16" width="1em" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" />
         </button>
-        <div
-          aria-label="100%"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="100"
-          class="overflow-hidden rounded-full bg-accented w-full h-1 absolute inset-x-0 bottom-0"
-          data-max="100"
-          data-slot="progress"
-          data-state="complete"
-          data-value="100"
-          role="progressbar"
-          style="transform: translateZ(0px);"
-        >
-          
-          <div
-            class="size-full rounded-full data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] bg-primary"
-            data-max="100"
-            data-slot="indicator"
-            data-state="complete"
-            data-value="100"
-            style="transform: translateX(0%);"
-          >
-            
-            
-          </div>
-          
+        <div aria-label="100%" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="absolute bg-accented bottom-0 h-1 inset-x-0 overflow-hidden rounded-full w-full" data-max="100" data-slot="progress" data-state="complete" data-value="100" role="progressbar">
+          <div class="bg-primary data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite] rounded-full size-full" data-max="100" data-slot="indicator" data-state="complete" data-value="100"></div>
         </div>
-        
-        
       </li>
-      
     </ol>
-    <span
-      aria-hidden="true"
-      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      tabindex="0"
-    >
-      
-      
-    </span>
-    
+    <span aria-hidden="true" tabindex="0"></span>
   </div>
-  
-  
-  <!--teleport end-->
-  
 </div>
 `;

--- a/packages/ui/src/components/Tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/components/Tooltip/Tooltip.spec.ts
@@ -28,6 +28,6 @@ describe("Tooltip", () => {
     const screen = page.render(TooltipWrapper, options);
     await nextTick();
 
-    expect(screen.container).toMatchSnapshot();
+    expect(screen.container.outerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Tooltip/__snapshots__/Tooltip.spec.ts.snap
+++ b/packages/ui/src/components/Tooltip/__snapshots__/Tooltip.spec.ts.snap
@@ -2,358 +2,74 @@
 
 exports[`Tooltip > renders correctly with class 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    data-grace-area-trigger=""
-    data-state="instant-open"
-  >
-    Trigger
-  </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] text-sm"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Tooltip
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <button aria-describedby="reka-tooltip-content-v-0" data-grace-area-trigger data-state="instant-open">Trigger</button>
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-sm" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Tooltip</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Tooltip
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Tooltip</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`Tooltip > renders correctly with shortcut 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    data-grace-area-trigger=""
-    data-state="instant-open"
-  >
-    Trigger
-  </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Tooltip
+  <button aria-describedby="reka-tooltip-content-v-0" data-grace-area-trigger data-state="instant-open">Trigger</button>
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Tooltip</span>
+      <span class="before:content-['·'] before:me-0.5 gap-0.5 inline-flex items-center shrink-0" data-slot="kbds">
+        <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+Z</kbd>
       </span>
-      <span
-        class="inline-flex shrink-0 items-center gap-0.5 before:me-0.5 before:content-['·']"
-        data-slot="kbds"
-      >
-        
-        <kbd
-          class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-          data-slot="base"
-        >
-          Ctrl+Z
-        </kbd>
-        
-      </span>
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        TooltipCtrl+Z
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">TooltipCtrl+Z</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`Tooltip > renders correctly with shortcut only 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    data-grace-area-trigger=""
-    data-state="instant-open"
-  >
-    Trigger
-  </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      />
-      <span
-        class="inline-flex shrink-0 items-center gap-0.5 before:me-0.5 before:content-['·']"
-        data-slot="kbds"
-      >
-        
-        <kbd
-          class="inline-flex items-center justify-center rounded-sm bg-default px-1 font-sans font-medium text-default ring ring-accented ring-inset h-4 min-w-4 text-[10px]"
-          data-slot="base"
-        >
-          Ctrl+S
-        </kbd>
-        
+  <button aria-describedby="reka-tooltip-content-v-0" data-grace-area-trigger data-state="instant-open">Trigger</button>
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text"></span>
+      <span class="before:content-['·'] before:me-0.5 gap-0.5 inline-flex items-center shrink-0" data-slot="kbds">
+        <kbd class="bg-default font-medium font-sans h-4 inline-flex items-center justify-center min-w-4 px-1 ring ring-accented ring-inset rounded-sm text-[10px] text-default" data-slot="base">Ctrl+S</kbd>
       </span>
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Ctrl+S
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Ctrl+S</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;
 
 exports[`Tooltip > renders correctly with text 1`] = `
 <div>
-  
-  
-  
-  <button
-    aria-describedby="reka-tooltip-content-v-0"
-    data-grace-area-trigger=""
-    data-state="instant-open"
-  >
-    Trigger
-  </button>
-  <!--teleport start-->
-  
-  
-  <div
-    data-reka-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, -200%); min-width: max-content; --reka-popper-transform-origin: ; z-index: auto;"
-  >
-    <div
-      class="pointer-events-auto flex h-6 origin-(--reka-tooltip-content-transform-origin) items-center gap-1 rounded-sm bg-default px-2.5 py-1 text-xs shadow-sm ring ring-default select-none data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out]"
-      data-align="center"
-      data-dismissable-layer=""
-      data-side="bottom"
-      data-slot="content"
-      data-state="instant-open"
-      style="--reka-tooltip-content-transform-origin: var(--reka-popper-transform-origin); --reka-tooltip-content-available-width: var(--reka-popper-available-width); --reka-tooltip-content-available-height: var(--reka-popper-available-height); --reka-tooltip-trigger-width: var(--reka-popper-anchor-width); --reka-tooltip-trigger-height: var(--reka-popper-anchor-height); animation: auto ease 0s 1 normal none running none;"
-    >
-      
-      
-      
-      
-      <span
-        class="truncate"
-        data-slot="text"
-      >
-        Tooltip
-      </span>
-      <!--v-if-->
-      <span
-        style="position: absolute; top: 0px; transform-origin: center 0px; transform: rotate(180deg); visibility: hidden;"
-      >
-        <svg
-          class="fill-default"
-          data-slot="arrow"
-          height="5"
-          preserveAspectRatio="none"
-          rounded="false"
-          style="display: block;"
-          viewBox="0 0 12 6"
-          width="10"
-        >
-          
-          <path
-            d="M0 0L6 6L12 0"
-          />
-          
+  <button aria-describedby="reka-tooltip-content-v-0" data-grace-area-trigger data-state="instant-open">Trigger</button>
+  <div data-reka-popper-content-wrapper>
+    <div class="bg-default data-[state=closed]:animate-[scale-out_100ms_ease-in] data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] flex gap-1 h-6 items-center origin-(--reka-tooltip-content-transform-origin) pointer-events-auto px-2.5 py-1 ring ring-default rounded-sm select-none shadow-sm text-xs" data-align="center" data-dismissable-layer data-side="bottom" data-slot="content" data-state="instant-open">
+      <span class="truncate" data-slot="text">Tooltip</span>
+      <span>
+        <svg class="fill-default" data-slot="arrow" height="5" preserveAspectRatio="none" rounded="false" viewBox="0 0 12 6" width="10">
+          <path d="M0 0L6 6L12 0" />
         </svg>
       </span>
-      
-      
-      
-      <span
-        aria-hidden="true"
-        id="reka-tooltip-content-v-0"
-        role="tooltip"
-        style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); white-space: nowrap; overflow-wrap: normal; top: -1px; left: -1px;"
-      >
-        
-        Tooltip
-        
-      </span>
-      
+      <span aria-hidden="true" id="reka-tooltip-content-v-0" role="tooltip">Tooltip</span>
     </div>
   </div>
-  
-  
-  <!--teleport end-->
-  
-  
-  
 </div>
 `;

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
     bail: isCI ? 1 : 0,
     reporters: isCI ? ["verbose", "github-actions"] : ["verbose"],
     setupFiles: ["./vitest.setup.ts", "vitest-browser-vue"],
+    snapshotSerializers: ["vue3-snapshot-serializer"],
     browser: {
       enabled: true,
       headless: isCI,

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,1 +1,13 @@
+import { beforeEach } from "vitest";
+
 import "./src/index.css";
+
+beforeEach(() => {
+  // @ts-expect-error `vue3-snapshot-serializer` currently doesn't provide any typings.
+  globalThis.vueSnapshots = {
+    formatter: "classic",
+
+    removeComments: true,
+    regexToRemoveAttributes: /style/,
+  };
+});

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,6 +1,11 @@
+import { addCollection } from "@iconify/vue";
+import lucideIcons from "@iconify-json/lucide/icons.json";
 import { beforeEach } from "vitest";
 
 import "./src/index.css";
+
+// Load Lucide icons offline.
+addCollection(lucideIcons);
 
 beforeEach(() => {
   // @ts-expect-error `vue3-snapshot-serializer` currently doesn't provide any typings.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@histoire/plugin-vue':
       specifier: 1.0.0-beta.1
       version: 1.0.0-beta.1
+    '@iconify-json/lucide':
+      specifier: 1.2.93
+      version: 1.2.93
     '@iconify/vue':
       specifier: 5.0.0
       version: 5.0.0
@@ -615,6 +618,9 @@ importers:
       '@histoire/plugin-vue':
         specifier: 'catalog:'
         version: 1.0.0-beta.1(histoire@1.0.0-beta.1(@types/node@24.10.13)(lightningcss@1.31.1)(tsx@4.21.0)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.28(typescript@5.9.3))
+      '@iconify-json/lucide':
+        specifier: 'catalog:'
+        version: 1.2.93
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.1.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -1236,6 +1242,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/lucide@1.2.93':
+    resolution: {integrity: sha512-xMbNHP3uS0c/jkgmj6k/9DcuqW7Ey88R0bM2hV5rOJ8wDARql6kM0UC/WCHOyfjh+7OIJnRuDqUvvStx2NHbNw==}
 
   '@iconify-json/simple-icons@1.2.69':
     resolution: {integrity: sha512-T/rhy5n7pzE0ZOxQVlF68SNPCYYjRBpddjgjrJO5WWVRG8es5BQmvxIE9kKF+t2hhPGvuGQFpXmUyqbOtnxirQ==}
@@ -7766,6 +7775,10 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/lucide@1.2.93':
+    dependencies:
+      '@iconify/types': 2.0.0
 
   '@iconify-json/simple-icons@1.2.69':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,9 @@ catalogs:
     vue-tsc:
       specifier: 3.2.4
       version: 3.2.4
+    vue3-snapshot-serializer:
+      specifier: 2.13.1
+      version: 2.13.1
     webdriverio:
       specifier: 9.24.0
       version: 9.24.0
@@ -651,6 +654,9 @@ importers:
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.4(typescript@5.9.3)
+      vue3-snapshot-serializer:
+        specifier: 'catalog:'
+        version: 2.13.1
       webdriverio:
         specifier: 'catalog:'
         version: 9.24.0
@@ -6947,6 +6953,9 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
+
+  vue3-snapshot-serializer@2.13.1:
+    resolution: {integrity: sha512-3AQAyDDcbGXNLiOp4rNNinRqwT0Uy/ahodk25r0OL/lV4+/P4nwLi6s2OeG/lkFfePgyFSaFMJTyp9+mp8loMw==}
 
   vue@3.5.28:
     resolution: {integrity: sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==}
@@ -14087,6 +14096,12 @@ snapshots:
       '@volar/typescript': 2.4.27
       '@vue/language-core': 3.2.4
       typescript: 5.9.3
+
+  vue3-snapshot-serializer@2.13.1:
+    dependencies:
+      cheerio: 1.2.0
+      htmlparser2: 10.1.0
+      js-beautify: 1.15.4
 
   vue@3.5.28(typescript@5.9.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,6 +114,7 @@ catalog:
   "@vue/test-utils": 2.4.6
   "@pinia/testing": 1.0.3
   "vitest-browser-vue": 2.0.2
+  "vue3-snapshot-serializer": 2.13.1
 
   # WebdriverIO
   "webdriverio": 9.24.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ catalog:
 
   # Styling
   "@iconify/vue": 5.0.0
+  "@iconify-json/lucide": 1.2.93
   "tailwindcss": 4.1.18
   "tailwind-merge": 3.4.0
   "tailwind-variants": 3.2.2


### PR DESCRIPTION
Now, component snapshots are cleaner and smaller. This change fixes the issue with the `style` attribute (managed by Reka UI) internally, which caused discrepancies between the local and CI environments.