### PR TITLE
fix: fix PDF export in non-Chromium browsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,6 @@ dependencies = [
  "borsh",
  "embroiderly_parsers",
  "embroiderly_pattern",
- "embroiderly_web",
  "js-sys",
  "serde",
  "serde_json",

--- a/app/src/stores/usePatternFileStore.ts
+++ b/app/src/stores/usePatternFileStore.ts
@@ -292,13 +292,17 @@ export const usePatternFileStore = defineStore(
         loading.value = true;
 
         const { exportPatternAsPdf } = await import("@embroiderly/pdf-export");
-        await exportPatternAsPdf({
-          handle,
+        const pdfBytes = await exportPatternAsPdf({
           pattern: patternData,
           options: PdfExportOptions.schema.serialize(pattern.pdfExportOptions),
           fonts: await Promise.all(pattern.palette.usedSymbolFonts.map((name) => files.loadFontContent(name))),
           variant,
         });
+
+        const writable = await handle.createWritable();
+        // @ts-expect-error `Uint8Array` works just fine here.
+        await writable.write(pdfBytes);
+        await writable.close();
 
         MetricsService.capturePatternExportedAsPdf(pattern.pdfExportOptions);
         toast.add({ color: "success", title: fluent.$t("pattern-export-success"), duration: 3000 });

--- a/packages/pdf-export/src-wasm/Cargo.toml
+++ b/packages/pdf-export/src-wasm/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # Embroiderly Core
 embroiderly_pattern = { workspace = true, features = ["borsh", "serde"] }
-embroiderly_web = { workspace = true, features = ["opfs"] }
 
 # De/serialization
 borsh = { workspace = true }

--- a/packages/pdf-export/src-wasm/src/lib.rs
+++ b/packages/pdf-export/src-wasm/src/lib.rs
@@ -21,24 +21,16 @@ impl std::fmt::Display for PdfVariant {
 }
 
 #[wasm_bindgen]
-pub async fn export_pdf(
-  file_handle: web_sys::FileSystemFileHandle,
+pub fn export_pdf(
   pattern: &[u8],
   options: &[u8],
   variant: PdfVariant,
   font_data: Vec<js_sys::Uint8Array>,
-) -> Result<(), JsError> {
+) -> Result<Vec<u8>, JsError> {
   let embproj = borsh::from_slice(pattern).map_err(|e| JsError::new(&e.to_string()))?;
   let options = borsh::from_slice(options).map_err(|e| JsError::new(&e.to_string()))?;
 
   let font_data: Vec<Vec<u8>> = font_data.iter().map(js_sys::Uint8Array::to_vec).collect();
 
-  let pdf_bytes =
-    pdf::export_pattern(embproj, options, variant, font_data).map_err(|e| JsError::new(&e.to_string()))?;
-  embroiderly_web::opfs::FileHandle::from(file_handle)
-    .write(&pdf_bytes)
-    .await
-    .map_err(|e| JsError::new(&e.to_string()))?;
-
-  Ok(())
+  pdf::export_pattern(embproj, options, variant, font_data).map_err(|e| JsError::new(&e.to_string()))
 }

--- a/packages/pdf-export/src/index.ts
+++ b/packages/pdf-export/src/index.ts
@@ -6,14 +6,14 @@ export * from "./types.ts";
 
 export async function exportPatternAsPdf(input: ExportInput) {
   const worker = new Worker(new URL("./worker.ts", import.meta.url), { type: "module" });
-  const api = Comlink.wrap<{ export: (input: ExportInput) => Promise<void> }>(worker);
+  const api = Comlink.wrap<{ export: (input: ExportInput) => Promise<Uint8Array> }>(worker);
   try {
     const transferables: Transferable[] = [
       input.pattern.buffer as ArrayBuffer,
       input.options.buffer as ArrayBuffer,
       ...input.fonts.map((f) => f.buffer as ArrayBuffer),
     ];
-    await api.export(Comlink.transfer(input, transferables));
+    return await api.export(Comlink.transfer(input, transferables));
   } finally {
     api[Comlink.releaseProxy]();
     worker.terminate();

--- a/packages/pdf-export/src/types.ts
+++ b/packages/pdf-export/src/types.ts
@@ -1,8 +1,6 @@
 export type PdfVariant = "monochrome" | "color";
 
 export interface ExportInput {
-  /** The file handle to write the PDF to. */
-  handle: FileSystemFileHandle;
   /** Borsh-serialised `EmbroiderlyProject`. */
   pattern: Uint8Array;
   /** Borsh-serialised `PdfExportOptions`. */

--- a/packages/pdf-export/src/worker.ts
+++ b/packages/pdf-export/src/worker.ts
@@ -5,13 +5,14 @@ import init, { export_pdf, PdfVariant } from "../src-wasm/pkg/";
 import type { ExportInput } from "./types.ts";
 
 const api = {
-  async export(input: ExportInput): Promise<void> {
+  async export(input: ExportInput): Promise<Uint8Array> {
     await init();
 
-    const { handle, pattern, options, fonts } = input;
+    const { pattern, options, fonts } = input;
     const variant = input.variant === "color" ? PdfVariant.Color : PdfVariant.Monochrome;
 
-    await export_pdf(handle, pattern, options, variant, fonts);
+    const pdfBytes = export_pdf(pattern, options, variant, fonts);
+    return Comlink.transfer(pdfBytes, [pdfBytes.buffer]);
   },
 };
 Comlink.expose(api);


### PR DESCRIPTION
The File System Access API (`showOpenFilePicker`/`showSaveFilePicker`) is only supported in Chrome and Edge. In other browsers, we utilize a polyfill which switches to a standard file managing using the ephemeral `input` element. Previously, we have been passing the mocked file handle object to the worker and the Wasm module which broken that handle. We fixed this issue by return a raw buffer from the Wasm module and writing it to the file on the main app side, where we have a valid file handle object.